### PR TITLE
Added fix for #64 to keep building in spite of javadoc errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,7 @@
                             <configuration>
                                 <doctitle><![CDATA[<h1>Robot Protocol Testing Tool</h1>]]></doctitle>
                                 <bottom><![CDATA[<i>Copyright &#169; 2014 Kaazing, Inc. All Rights Reserved.</i>]]></bottom>
+                                <additionalparam>-Xdoclint:none</additionalparam>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
There is some debate about switching this to be the default in the Maven Javadoc plugin (https://jira.codehaus.org/browse/MJAVADOC-387).

Since I could not find a solution that would let us enable some of the checks and disable others (for the Mojo classes that fail) I think robot builds should disable JDK8 lint checking for javadoc by default.
