### PR TITLE
Removed robot.all due to javadoc/source not loading in eclipse and it no...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <module>lang</module>
         <module>driver</module>
         <module>robot-maven-plugin</module>
-        <module>all</module>
+<!--        <module>all</module>  -->
     </modules>
 
     <distributionManagement>


### PR DESCRIPTION
...t being included in deployment which makes rules fail
