### PR TITLE
Avoid stack overflow when exception occurs during close.

### DIFF
--- a/driver/src/main/java/org/kaazing/k3po/driver/Robot.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/Robot.java
@@ -19,6 +19,7 @@
 
 package org.kaazing.k3po.driver;
 
+import static java.lang.Boolean.TRUE;
 import static java.lang.String.format;
 import static org.jboss.netty.channel.Channels.pipeline;
 import static org.jboss.netty.channel.Channels.pipelineFactory;
@@ -497,9 +498,17 @@ public class Robot {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) throws Exception {
-            // close channel and avoid warning logged by default exceptionCaught implementation
-            Channel channel = ctx.getChannel();
-            channel.close();
+            // avoid stack overflow when exception happens on close
+            if (TRUE != ctx.getAttachment()) {
+                ctx.setAttachment(TRUE);
+                // close channel and avoid warning logged by default exceptionCaught implementation
+                Channel channel = ctx.getChannel();
+                channel.close();
+            }
+            else {
+                // log exception during close
+                super.exceptionCaught(ctx, e);
+            }
         }
     }
 

--- a/driver/src/main/java/org/kaazing/k3po/driver/behavior/handler/event/AbstractEventHandler.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/behavior/handler/event/AbstractEventHandler.java
@@ -103,8 +103,9 @@ public abstract class AbstractEventHandler extends ExecutionHandler {
         } else {
             ChannelFuture pipelineFuture = getPipelineFuture();
             if (!pipelineFuture.isSuccess()) {
-                handlerFuture.setFailure(new ChannelException("Expected event arrived too early").fillInStackTrace());
-
+                // expected event arrived too early
+                Exception exception = new ScriptProgressException(getRegionInfo(), format("%s", this));
+                handlerFuture.setFailure(exception.fillInStackTrace());
             } else {
                 super.handleUpstream1(ctx, evt);
             }


### PR DESCRIPTION
Report 'expected event arrived too early' via script, not stack trace.
