### PR TITLE
Normalize the path before passing to class loader to load resource

### DIFF
--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlServerHandler.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlServerHandler.java
@@ -149,7 +149,8 @@ public class ControlServerHandler extends ControlUpstreamHandler {
         final StringBuilder aggregatedScript = new StringBuilder();
         for (String scriptName : scriptNames) {
             String scriptNameWithExtension = format("%s.rpt", scriptName);
-            Path scriptPath = Paths.get(scriptNameWithExtension);
+            Path scriptPath = Paths.get(scriptNameWithExtension).normalize();
+            scriptNameWithExtension = scriptPath.toString();
             String script = null;
 
             assert !scriptPath.isAbsolute();


### PR DESCRIPTION
I am trying to use scripts from multiple locations(from specification jars and local file paths). Without normalization, classloader doesn't load the resources. This changeset fixes that issue.

```
private final K3poRule robot = new K3poRule().setScriptRoot("org/kaazing/specification/ws/framing");
@Specification({
       "echo.binary.payload.length.125/handshake.request.and.frame",
       "../../../../../com/kaazing/gateway/server/transport/socks/ws.socks.ws.data.exchange" })
    public void test() throws Exception {
```
