### PR TITLE
k3po #232: fix scripts in specification/wse/data to avoid assuming RECONNECT will

### DIFF
--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary.as.escaped.text/echo.payload.length.0/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary.as.escaped.text/echo.payload.length.0/request.rpt
@@ -52,9 +52,4 @@ write header "X-Sequence-No" ${wse:asString(sequence + 1)}
 write header content-length
 
 write [0xC2 0x80 0x7F 0x3F]
-write [0x01 0x30 0x31 0xC3 0xBF]
-write close
-
-read status "200" /.+/
-read version "HTTP/1.1"
-read closed
+write flush

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary.as.escaped.text/echo.payload.length.0/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary.as.escaped.text/echo.payload.length.0/response.rpt
@@ -56,11 +56,4 @@ read header "Content-Type" /text\/plain;charset=(?i)utf-8/
 read header "X-Sequence-No" ${wse:asString(sequence + 1)}
 
 read [0xC2 0x80 0x7F 0x3F]
-read [0x01 0x30 0x31 0xC3 0xBF]
 read notify DATA_RECEIVED
-read closed
-
-write status "200" "OK"
-write version "HTTP/1.1"
-write header content-length
-write close

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary.as.text/echo.payload.length.0/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary.as.text/echo.payload.length.0/request.rpt
@@ -52,9 +52,4 @@ write header "X-Sequence-No" ${wse:asString(sequence + 1)}
 write header content-length
 
 write [0xC2 0x80 0x11]
-write [0x01 0x30 0x31 0xC3 0xBF]
-write close
-
-read status "200" /.+/
-read version "HTTP/1.1"
-read closed
+write flush

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary.as.text/echo.payload.length.0/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary.as.text/echo.payload.length.0/response.rpt
@@ -56,11 +56,4 @@ read header "Content-Type" /text\/plain;charset=(?i)utf-8/
 read header "X-Sequence-No" ${wse:asString(sequence + 1)}
 
 read [0xC2 0x80 0x11]
-read [0x01 0x30 0x31 0xC3 0xBF]
 read notify DATA_RECEIVED
-read closed
-
-write status "200" "OK"
-write version "HTTP/1.1"
-write header content-length
-write close

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.0/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.0/request.rpt
@@ -51,9 +51,4 @@ write header "X-Sequence-No" ${wse:asString(sequence + 1)}
 write header content-length
 
 write [0x80 0x00]
-write [0x01 0x30 0x31 0xFF]
-write close
-
-read status "200" /.+/
-read version "HTTP/1.1"
-read closed
+write flush

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.0/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.0/response.rpt
@@ -56,11 +56,4 @@ read header "Content-Type" "application/octet-stream"
 read header "X-Sequence-No" ${wse:asString(sequence + 1)}
 
 read [0x80 0x00]
-read [0x01 0x30 0x31 0xFF]
 read notify DATA_RECEIVED
-read closed
-
-write status "200" "OK"
-write version "HTTP/1.1"
-write header content-length
-write close

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.127/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.127/request.rpt
@@ -52,9 +52,4 @@ write header "X-Sequence-No" ${wse:asString(sequence + 1)}
 write header content-length
 
 write [0x80 0x7F] ${client127}
-write [0x01 0x30 0x31 0xFF]
-write close
-
-read status "200" /.+/
-read version "HTTP/1.1"
-read closed
+write flush

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.127/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.127/response.rpt
@@ -57,11 +57,4 @@ read header "X-Sequence-No" ${wse:asString(sequence + 1)}
 
 read [0x80 0x7F]
 read ([0..127] :server127)
-read [0x01 0x30 0x31 0xFF]
 read notify DATA_RECEIVED
-read closed
-
-write status "200" "OK"
-write version "HTTP/1.1"
-write header content-length
-write close

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.128/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.128/request.rpt
@@ -52,9 +52,4 @@ write header "X-Sequence-No" ${wse:asString(sequence + 1)}
 write header content-length
 
 write [0x80 0x81 0x00] ${client128}
-write [0x01 0x30 0x31 0xFF]
-write close
-
-read status "200" /.+/
-read version "HTTP/1.1"
-read closed
+write flush

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.128/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.128/response.rpt
@@ -57,11 +57,4 @@ read header "X-Sequence-No" ${wse:asString(sequence + 1)}
 
 read [0x80 0x81 0x00]
 read ([0..128] :server128)
-read [0x01 0x30 0x31 0xFF]
 read notify DATA_RECEIVED
-read closed
-
-write status "200" "OK"
-write version "HTTP/1.1"
-write header content-length
-write close

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.65535/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.65535/request.rpt
@@ -53,9 +53,4 @@ write header content-length
 
 write [0x80 0x83 0xFF 0x7F]
 write ${client65535}
-write [0x01 0x30 0x31 0xFF]
-write close
-
-read status "200" /.+/
-read version "HTTP/1.1"
-read closed
+write flush

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.65535/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.65535/response.rpt
@@ -56,11 +56,4 @@ read header "X-Sequence-No" ${wse:asString(sequence + 1)}
 
 read [0x80 0x83 0xFF 0x7F]
 read ([0..65535] :server65535)
-read [0x01 0x30 0x31 0xFF]
 read notify DATA_RECEIVED
-read closed
-
-write status "200" "OK"
-write version "HTTP/1.1"
-write header content-length
-write close

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.65536/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.65536/request.rpt
@@ -52,9 +52,4 @@ write header "X-Sequence-No" ${wse:asString(sequence + 1)}
 write header content-length
 
 write [0x80 0x84 0x80 0x00] ${client65536}
-write [0x01 0x30 0x31 0xFF]
-write close
-
-read status "200" /.+/
-read version "HTTP/1.1"
-read closed
+write flush

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.65536/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary/echo.payload.length.65536/response.rpt
@@ -57,11 +57,5 @@ read header "X-Sequence-No" ${wse:asString(sequence + 1)}
 
 read [0x80 0x84 0x80 0x00]
 read ([0..65536] :server65536)
-read [0x01 0x30 0x31 0xFF]
 read notify DATA_RECEIVED
-read closed
 
-write status "200" "OK"
-write version "HTTP/1.1"
-write header content-length
-write close


### PR DESCRIPTION
be immediately sent with the upstream data, to accomodate clients such as WsebConnector which use the same upstream request for multiple chunks of upstream data. This should at least partially resolve k3po issue #232.