### PR TITLE
Defer resolving accept and connect options until needed by accept or connect behavior

### DIFF
--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/visitor/GenerateConfigurationVisitor.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/visitor/GenerateConfigurationVisitor.java
@@ -104,6 +104,7 @@ import org.kaazing.k3po.driver.internal.netty.bootstrap.BootstrapFactory;
 import org.kaazing.k3po.driver.internal.netty.channel.ChannelAddressFactory;
 import org.kaazing.k3po.driver.internal.resolver.ClientBootstrapResolver;
 import org.kaazing.k3po.driver.internal.resolver.LocationResolver;
+import org.kaazing.k3po.driver.internal.resolver.OptionsResolver;
 import org.kaazing.k3po.driver.internal.resolver.ServerBootstrapResolver;
 import org.kaazing.k3po.lang.internal.RegionInfo;
 import org.kaazing.k3po.lang.internal.ast.AstAcceptNode;
@@ -152,7 +153,6 @@ import org.kaazing.k3po.lang.internal.ast.matcher.AstVariableLengthBytesMatcher;
 import org.kaazing.k3po.lang.internal.ast.value.AstExpressionValue;
 import org.kaazing.k3po.lang.internal.ast.value.AstLiteralBytesValue;
 import org.kaazing.k3po.lang.internal.ast.value.AstLiteralTextValue;
-import org.kaazing.k3po.lang.internal.ast.value.AstLocation;
 import org.kaazing.k3po.lang.internal.ast.value.AstValue;
 import org.kaazing.k3po.lang.internal.el.ExpressionContext;
 
@@ -341,25 +341,8 @@ public class GenerateConfigurationVisitor implements AstNode.Visitor<Configurati
 
         Map<String, Object> acceptOptions = new HashMap<>();
         acceptOptions.put("regionInfo", acceptInfo);
-        Map<String, Object> acceptNodeOptions = acceptNode.getOptions();
-        AstLocation transport = (AstLocation) acceptNodeOptions.get("transport");
-        LocationResolver transportResolver = null;
-        if (transport != null) {
-            transportResolver = new LocationResolver(transport, acceptNode.getEnvironment());
-        }
-        acceptOptions.putAll(acceptNodeOptions);
-
-        // TODO: defer "reader", expression evaluation
-        AstExpressionValue readerOption = (AstExpressionValue) acceptNodeOptions.get("reader");
-        if (readerOption != null) {
-            acceptOptions.put("reader", readerOption.getValue().getValue(readerOption.getEnvironment()));
-        }
-
-        // TODO: defer "writer", expression evaluation
-        AstExpressionValue writerOption = (AstExpressionValue) acceptNodeOptions.get("writer");
-        if (writerOption != null) {
-            acceptOptions.put("writer", writerOption.getValue().getValue(writerOption.getEnvironment()));
-        }
+        acceptOptions.putAll(acceptNode.getOptions());
+        OptionsResolver optionsResolver = new OptionsResolver(acceptOptions, acceptNode.getEnvironment());
 
         // Now that accept supports expression value, accept uri may not be available at this point.
         // To defer the evaluation of accept uri and initialization of  ServerBootstrap, LocationResolver and
@@ -367,7 +350,7 @@ public class GenerateConfigurationVisitor implements AstNode.Visitor<Configurati
         // accept uri is available.
         LocationResolver locationResolver = new LocationResolver(acceptNode.getLocation(), acceptNode.getEnvironment());
         ServerBootstrapResolver serverResolver = new ServerBootstrapResolver(bootstrapFactory, addressFactory,
-                pipelineFactory, locationResolver, transportResolver, acceptOptions);
+                pipelineFactory, locationResolver, optionsResolver);
 
         state.configuration.getServerResolvers().add(serverResolver);
 
@@ -428,29 +411,10 @@ public class GenerateConfigurationVisitor implements AstNode.Visitor<Configurati
         // ClientResolver are created with information necessary to create ClientBootstrap when the connect uri
         // is available.
         LocationResolver locationResolver = new LocationResolver(connectNode.getLocation(), connectNode.getEnvironment());
-        Map<String, Object> connectOptions = new HashMap<>();
-        Map<String, Object> connectNodeOptions = connectNode.getOptions();
-        AstLocation transport = (AstLocation) connectNodeOptions.get("transport");
-        LocationResolver transportResolver = null;
-        if (transport != null) {
-            transportResolver = new LocationResolver(transport, connectNode.getEnvironment());
-        }
-        connectOptions.putAll(connectNodeOptions);
-
-        // TODO: defer "reader", expression evaluation
-        AstExpressionValue readerOption = (AstExpressionValue) connectNodeOptions.get("reader");
-        if (readerOption != null) {
-            connectOptions.put("reader", readerOption.getValue().getValue(readerOption.getEnvironment()));
-        }
-
-        // TODO: defer "writer", expression evaluation
-        AstExpressionValue writerOption = (AstExpressionValue) connectNodeOptions.get("writer");
-        if (writerOption != null) {
-            connectOptions.put("writer", writerOption.getValue().getValue(writerOption.getEnvironment()));
-        }
+        OptionsResolver optionsResolver = new OptionsResolver(connectNode.getOptions(), connectNode.getEnvironment());
 
         ClientBootstrapResolver clientResolver = new ClientBootstrapResolver(bootstrapFactory, addressFactory,
-                pipelineFactory, locationResolver, transportResolver, barrier, connectNode.getRegionInfo(), connectOptions);
+                pipelineFactory, locationResolver, optionsResolver, barrier, connectNode.getRegionInfo());
 
         // retain pipelines for tear down
         state.configuration.getClientAndServerPipelines().add(pipeline);

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/ClientBootstrapResolver.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/ClientBootstrapResolver.java
@@ -43,32 +43,27 @@ public class ClientBootstrapResolver {
     private final LocationResolver locationResolver;
     private final Barrier barrier;
     private final RegionInfo regionInfo;
-    private final Map<String, Object> connectOptions;
-    private final LocationResolver transportResolver;
+    private final OptionsResolver optionsResolver;
 
     private ClientBootstrap bootstrap;
 
     public ClientBootstrapResolver(BootstrapFactory bootstrapFactory, ChannelAddressFactory addressFactory,
             ChannelPipelineFactory pipelineFactory, LocationResolver locationResolver,
-            LocationResolver transportResolver, Barrier barrier,
-            RegionInfo regionInfo, Map<String, Object> connectOptions) {
+            OptionsResolver optionsResolver, Barrier barrier,
+            RegionInfo regionInfo) {
         this.bootstrapFactory = bootstrapFactory;
         this.addressFactory = addressFactory;
         this.pipelineFactory = pipelineFactory;
         this.locationResolver = locationResolver;
-        this.transportResolver = transportResolver;
+        this.optionsResolver = optionsResolver;
         this.barrier = barrier;
         this.regionInfo = regionInfo;
-        this.connectOptions = connectOptions;
     }
 
     public ClientBootstrap resolve() throws Exception {
         if (bootstrap == null) {
             URI connectURI = locationResolver.resolve();
-            if (transportResolver != null) {
-                URI transportURI = transportResolver.resolve();
-                connectOptions.put("transport", transportURI);
-            }
+            Map<String, Object> connectOptions = optionsResolver.resolve();
             ChannelAddress remoteAddress = addressFactory.newChannelAddress(connectURI, connectOptions);
             LOGGER.debug("Initializing client Bootstrap connecting to remoteAddress " + remoteAddress);
             ClientBootstrap clientBootstrapCandidate = bootstrapFactory.newClientBootstrap(connectURI.getScheme());

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/OptionsResolver.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/OptionsResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.k3po.driver.internal.resolver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.el.ELContext;
+
+import org.kaazing.k3po.lang.internal.ast.value.AstExpressionValue;
+import org.kaazing.k3po.lang.internal.ast.value.AstLocationLiteral;
+
+/**
+ * The class is used to defer the evaluation of accept and connect options.
+ */
+public final class OptionsResolver {
+
+    private final Map<String, Object> options;
+    private final ELContext environment;
+
+    private Map<String, Object> resolved;
+
+    public OptionsResolver(Map<String, Object> options, ELContext environment) {
+        this.options = options;
+        this.environment = environment;
+    }
+
+    public Map<String, Object> resolve() {
+
+        if (resolved == null) {
+            resolved = new HashMap<String, Object>();
+            for (String name : options.keySet()) {
+                Object value = options.get(name);
+                if (value instanceof AstExpressionValue) {
+                    AstExpressionValue expressionValue = (AstExpressionValue) value;
+                    value = expressionValue.getValue().getValue(environment);
+                }
+                else if (value instanceof AstLocationLiteral) {
+                    AstLocationLiteral location = (AstLocationLiteral) value;
+                    value = location.getValue();
+                }
+                resolved.put(name, value);
+            }
+        }
+
+        return resolved;
+    }
+}

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/ServerBootstrapResolver.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/ServerBootstrapResolver.java
@@ -38,30 +38,24 @@ public class ServerBootstrapResolver {
     private final ChannelAddressFactory addressFactory;
     private final ChannelPipelineFactory pipelineFactory;
     private final LocationResolver locationResolver;
-    private final LocationResolver transportResolver;
-
-    private final Map<String, Object> acceptOptions;
+    private final OptionsResolver optionsResolver;
 
     private ServerBootstrap bootstrap;
 
     public ServerBootstrapResolver(BootstrapFactory bootstrapFactory, ChannelAddressFactory addressFactory,
             ChannelPipelineFactory pipelineFactory, LocationResolver locationResolver,
-            LocationResolver transportResolver, Map<String, Object> acceptOptions) {
+            OptionsResolver optionsResolver) {
         this.bootstrapFactory = bootstrapFactory;
         this.addressFactory = addressFactory;
         this.pipelineFactory = pipelineFactory;
         this.locationResolver = locationResolver;
-        this.transportResolver = transportResolver;
-        this.acceptOptions = acceptOptions;
+        this.optionsResolver = optionsResolver;
     }
 
     public ServerBootstrap resolve() throws Exception {
         if (bootstrap == null) {
             URI acceptURI = locationResolver.resolve();
-            if (transportResolver != null) {
-                URI transportURI = transportResolver.resolve();
-                acceptOptions.put("transport", transportURI);
-            }
+            Map<String, Object> acceptOptions = optionsResolver.resolve();
             ChannelAddress localAddress = addressFactory.newChannelAddress(acceptURI, acceptOptions);
             LOGGER.debug("Initializing server Bootstrap binding to address " + localAddress);
             ServerBootstrap serverBootstrapCandidate = bootstrapFactory.newServerBootstrap(acceptURI.getScheme());

--- a/k3po-maven-plugin/src/main/java/org/kaazing/k3po/maven/plugin/internal/StartMojo.java
+++ b/k3po-maven-plugin/src/main/java/org/kaazing/k3po/maven/plugin/internal/StartMojo.java
@@ -57,6 +57,9 @@ public class StartMojo extends AbstractMojo {
     @Parameter(defaultValue = "false", property = "maven.k3po.verbose")
     private boolean verbose;
 
+    @Parameter(property = "basedir")
+    private File workingDirectory;
+
     public URI getControl() {
         return controlURI;
     }
@@ -69,6 +72,12 @@ public class StartMojo extends AbstractMojo {
     protected void executeImpl() throws MojoExecutionException {
 
         try {
+            Log log = getLog();
+            if (log.isDebugEnabled()) {
+                log.debug(format("Setting System property \"user.dir\" to [%s]", workingDirectory.getAbsolutePath()));
+            }
+            System.setProperty("user.dir", workingDirectory.getAbsolutePath());
+
             ClassLoader scriptLoader = createScriptLoader();
 
             RobotServer server = new RobotServer(getControl(), verbose, scriptLoader);
@@ -82,7 +91,6 @@ public class StartMojo extends AbstractMojo {
             // setDefaultFactory(new Slf4JLoggerFactory());
 
             // use Maven3 logger for Robot when started via plugin
-            Log log = getLog();
             setDefaultFactory(new MavenLoggerFactory(log));
 
             long checkpoint = currentTimeMillis();


### PR DESCRIPTION
Resolve accept and connect options at the point of bind (accept) or connect, not during script parse or transformation.

Add workingDirectory to StartMojo, defaulted to ${basedir} to match surefire and failsafe, important for multi-module builds.