### PR TITLE
Log the "FAILED during remove" message in ExecutionHandler at debug level

### DIFF
--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/ExecutionHandler.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/ExecutionHandler.java
@@ -125,7 +125,7 @@ public class ExecutionHandler extends SimplePrepareUpstreamHandler implements Li
         assert handlerFuture != null;
         if (!handlerFuture.isDone()) {
             int id = (channel != null) ? channel.getId() : 0;
-            LOGGER.info(format("[id: 0x%08x] %s [FAILED during remove], pipelineFuture:\n%s",
+            LOGGER.debug(format("[id: 0x%08x] %s [FAILED during remove], pipelineFuture:\n%s",
                     id, ExecutionHandler.this, pipelineFuture));
             ScriptProgressException exception = new ScriptProgressException(getRegionInfo(), "");
             exception.fillInStackTrace();


### PR DESCRIPTION
instead of info level to avoid unnecessary build output.