### PR TITLE
Updated annotations of StopMojo, which with out was causing a error l…

### DIFF
--- a/k3po-maven-plugin/src/main/java/org/kaazing/k3po/maven/plugin/internal/StopMojo.java
+++ b/k3po-maven-plugin/src/main/java/org/kaazing/k3po/maven/plugin/internal/StopMojo.java
@@ -19,18 +19,14 @@ package org.kaazing.k3po.maven.plugin.internal;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
 import static java.lang.System.identityHashCode;
+import static org.apache.maven.plugins.annotations.LifecyclePhase.POST_INTEGRATION_TEST;
+import static org.apache.maven.plugins.annotations.ResolutionScope.TEST;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
 import org.kaazing.k3po.driver.internal.RobotServer;
 
-/**
- * Stop K3PO
- *
- * @goal stop
- * @phase post-integration-test
- *
- * @requiresDependencyResolution test
- */
+@Mojo(name = "stop", defaultPhase = POST_INTEGRATION_TEST, requiresDependencyResolution = TEST)
 public class StopMojo extends AbstractMojo {
 
     protected void executeImpl() throws MojoExecutionException {


### PR DESCRIPTION
…og 'k3po not running' with SkipTests as goal was executing at default stage, and not following skipTests