### PR TITLE
Issue 282 wse invalid upstream body

### DIFF
--- a/specification/wse/SPEC.md
+++ b/specification/wse/SPEC.md
@@ -408,7 +408,8 @@ If `X-Sequence-No` header is missing in upstream request, then the server MUST g
 If the sequence number received via `X-Sequence-No` header is out of order or invalid, the server MUST generate an HTTP response with a `400 Bad Request` status code and fail the WSE connection. Please see [Request Sequencing](#request-sequencing) for details.
 
 Otherwise, the server decodes the emulated WebSocket frames from the upstream request body and generates an HTTP upstream 
-response as follows.
+response. If the upstream request body is invalid, for example, it contains an invalid emulated WebSocket frame, the server MUST generate an HTTP response with a `400 Bad Request` status code and fail the WSE connection. Otherwise the following applies:
+
 * the upstream HTTP response body MUST have status code `200` 
 * the upstream HTTP response body MUST be empty with a `Content-Length` header value of `0` 
 

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.invalid.ping/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.invalid.ping/request.rpt
@@ -73,6 +73,6 @@ write [0x89 0x01]
 write [0x01 0x30 0x31 0xFF]
 write close
 
-read status "200" /.+/
+read status "400" /.+/
 read version "HTTP/1.1"
 read closed

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.invalid.ping/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.invalid.ping/response.rpt
@@ -76,7 +76,7 @@ read notify INVALID_PING_RECEIVED
 read [0x01 0x30 0x31 0xFF]
 read closed
 
-write status "200" "OK"
+write status "400" "Bad Request" 
 write version "HTTP/1.1"
 write header content-length
 write close

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.invalid.pong/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.invalid.pong/request.rpt
@@ -73,6 +73,6 @@ write [0x8A 0x01]
 write [0x01 0x30 0x31 0xFF]
 write close
 
-read status "200" /.+/
+read status "400" /.+/
 read version "HTTP/1.1"
 read closed

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.invalid.pong/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.invalid.pong/response.rpt
@@ -75,7 +75,7 @@ read [0x01 0x30 0x31 0xFF]
 read notify INVALID_PONG_RECEIVED
 read closed
 
-write status "200" "OK"
+write status "400" "Bad Request"
 write version "HTTP/1.1"
 write header content-length
 write close

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.ping/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.ping/request.rpt
@@ -72,6 +72,6 @@ write [0x89 0x00]
 write [0x01 0x30 0x31 0xFF]
 write close
 
-read status "200" /.+/
+read status "400" /.+/
 read version "HTTP/1.1"
 read closed

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.ping/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.ping/response.rpt
@@ -75,7 +75,7 @@ read notify PING_RECEIVED
 read [0x01 0x30 0x31 0xFF]
 read closed
 
-write status "200" "OK"
+write status "400" "Bad Request"
 write version "HTTP/1.1"
 write header content-length
 write close

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.pong/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.pong/request.rpt
@@ -72,6 +72,6 @@ write [0x8A 0x00]
 write [0x01 0x30 0x31 0xFF]
 write close
 
-read status "200" /.+/
+read status "400" /.+/
 read version "HTTP/1.1"
 read closed

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.pong/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.pong/response.rpt
@@ -75,7 +75,7 @@ read notify PONG_RECEIVED
 read [0x01 0x30 0x31 0xFF]
 read closed
 
-write status "200" "OK"
+write status "400" "Bad Request"
 write version "HTTP/1.1"
 write header content-length
 write close


### PR DESCRIPTION
This PR is intended to fix #282 
- wse SPEC.md changes to mandate that the server MUST generate an HTTP response with a 400 Bad Request status code and fail the WSE connection in the case of an upstream request with an invalid body (e.g. containing an invalid emulated WebSocket frame).
- wse script changes to reflect the above