### PR TITLE
Wse binary as escaped text: spec and test fixes

### DIFF
--- a/specification/wse/SPEC.md
+++ b/specification/wse/SPEC.md
@@ -647,9 +647,9 @@ Therefore, the client and server MUST escape these characters as follows (in bot
 | Byte Value | Character | UTF-8 Escaped Byte Sequence | Windows-1252 Escaped Byte Sequence | Escaped Characters |
 |------------|-----------|-----------------------------|------------------------------------|--------------------|
 | 0x00       | \0        | 0x7f 0x00                   | 0x7f 0x30                          | DEL 0              |
-| 0x0d       | \r        | 0x7f 0x72                   | 0x7f 0x00                          | DEL r              |
-| 0x0a       | \n        | 0x7f 0x6e                   | 0x7f 0x00                          | DEL n              |
-| 0x7f       | DEL       | 0x7f 0x7f                   | 0x7f 0x00                          | DEL DEL            |
+| 0x0d       | \r        | 0x7f 0x72                   | 0x7f 0x72                          | DEL r              |
+| 0x0a       | \n        | 0x7f 0x6e                   | 0x7f 0x6e                          | DEL n              |
+| 0x7f       | DEL       | 0x7f 0x7f                   | 0x7f 0x7f                          | DEL DEL            |
 
 Reference: [utf-8](https://en.wikipedia.org/wiki/UTF-8), [windows-1252](https://en.wikipedia.org/wiki/Windows-1252)
 

--- a/specification/wse/src/main/java/org/kaazing/specification/wse/internal/Functions.java
+++ b/specification/wse/src/main/java/org/kaazing/specification/wse/internal/Functions.java
@@ -74,7 +74,17 @@ public final class Functions {
     }
 
     @Function
-    public static byte[] escapeBytes(byte[] bytes) {
+    public static byte[] convertEscapedUtf8BytesToEscapedWindows1252(byte[] in) {
+        byte[] out = new byte[in.length];
+
+        for (int i = 0; i < in.length; i++) {
+            out[i] = in[i] == 0x00 ? 0x30 : in[i];
+        }
+        return out;
+    }
+
+    @Function
+    public static byte[] escapeBytesForUtf8(byte[] bytes) {
         List<Byte> listOfEscapedBytes = new ArrayList<Byte>();
         for (int i = 0; i < bytes.length; i++) {
             switch (bytes[i]) {
@@ -85,6 +95,28 @@ public final class Functions {
                 listOfEscapedBytes.add(new Byte((byte) 0b01111111));
             default:
                 listOfEscapedBytes.add(new Byte(bytes[i]));
+            }
+        }
+        bytes = new byte[listOfEscapedBytes.size()];
+        for (int i = 0; i < listOfEscapedBytes.size(); i++) {
+            bytes[i] = listOfEscapedBytes.get(i);
+        }
+        return bytes;
+    }
+
+    @Function
+    public static byte[] escapeBytesForWindows1252(byte[] bytes) {
+        List<Byte> listOfEscapedBytes = new ArrayList<Byte>();
+        for (int i = 0; i < bytes.length; i++) {
+            switch (bytes[i]) {
+            case 0b00000000:
+            case 0b00001101:
+            case 0b00001010:
+            case 0b01111111:
+                listOfEscapedBytes.add(new Byte((byte) 0b01111111));
+            default:
+                byte b = bytes[i] == 0b00000000 ? 0x30 : bytes[i];
+                listOfEscapedBytes.add(new Byte(b));
             }
         }
         bytes = new byte[listOfEscapedBytes.size()];

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary.as.escaped.text/echo.payload.length.127/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary.as.escaped.text/echo.payload.length.127/request.rpt
@@ -16,7 +16,8 @@
 
 property sequence ${wse:randomInt(100)}
 property client127 ${wse:randomBytesIncludingNumberOfEscapedBytes(127, 4)}
-property escapedClient127 ${wse:escapeBytes(client127)}
+property escapedUtf8Client127 ${wse:escapeBytesForUtf8(client127)}
+property escaped1252Client127 ${wse:escapeBytesForWindows1252(client127)}
 
 connect http://localhost:8080/path/;e/cte?query
 connected
@@ -55,7 +56,7 @@ read header "Content-Type" "text/plain;charset=windows-1252"
 read header "Connection" "close"
 
 read [0x80 0x7F]
-read [0..127]
+read ${escaped1252Client127}
 
 # Upstream
 connect await CREATED
@@ -69,6 +70,6 @@ write header "Content-Type" "text/plain;charset=utf-8"
 write header "X-Sequence-No" ${wse:asString(sequence + 1)}
 write header content-length
 
-write [0xC2 0x80 0x7F] ${escapedClient127}
+write [0xC2 0x80 0x7F] ${escapedUtf8Client127}
 write flush
 

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary.as.escaped.text/echo.payload.length.127/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/binary.as.escaped.text/echo.payload.length.127/response.rpt
@@ -58,7 +58,7 @@ write flush
 
 write await DATA_RECEIVED
 write [0x80 0x7F]
-write ${wse:unescapeBytesAndConvertToEscapedWindows1252(server127)}
+write ${wse:convertEscapedUtf8BytesToEscapedWindows1252(server127)}
 write flush
 
 # Upstream

--- a/specification/wse/src/test/java/org/kaazing/specification/wse/data/BinaryAsEscapedTextIT.java
+++ b/specification/wse/src/test/java/org/kaazing/specification/wse/data/BinaryAsEscapedTextIT.java
@@ -18,7 +18,6 @@ package org.kaazing.specification.wse.data;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -57,7 +56,6 @@ public class BinaryAsEscapedTextIT {
     }
 
     @Test
-    @Ignore("To be completed when wse spec is complete")
     @Specification({
         "echo.payload.length.127/request",
         "echo.payload.length.127/response" })


### PR DESCRIPTION
- In wse SPEC.md, fixed the values in the Windows-1252 column of the table in section Binary as Escaped Text (they should be same as in the UTF-8 case, except for 0x00)
- Completed wse specification test BinaryAsEscapedTextIT.shouldEchoFrameWithPayloadLength127, adding needed functions to Functions