### PR TITLE
(#298) Changed WSE SPEC.md to allow clients to include a request body…

### DIFF
--- a/specification/wse/SPEC.md
+++ b/specification/wse/SPEC.md
@@ -156,7 +156,7 @@ WebSocket connection.
 Clients SHOULD send the `X-Accept-Commands` HTTP header with the value `ping` to indicate that both `PING` and `PONG` frames 
 are understood by the client.
 
-Clients SHOULD send an empty handshake request body.
+Clients MUST send an empty handshake request body.
 
 For example, given the WebSocket Emulation URL `ws://host.example.com:8080/path?query` and binary encoding.
 
@@ -242,7 +242,8 @@ process the handshake request to generate a handshake response.
 If the server determines that any of the following conditions are not met by the HTTP handshake request, then the server MUST
 send an HTTP response with a `4xx` status code, such as `400 Bad Request`.
 
-* the HTTP handshake request method SHOULD be `POST`
+* the HTTP handshake request method SHOULD be `POST` with an empty request body
+* for compatibility with existing clients that are not fully compliant with this specification, the request body MAY not be empty
 * for compatibility with existing clients that are not fully compliant with this specification, the HTTP handshake request method MAY be `GET`
 * the HTTP handshake request header `X-WebSocket-Version` MUST have the value `wseb-1.0`
 * the HTTP handshake request header `X-Sequence-No` MUST be a valid sequence number. Please see [Request Sequencing](#request-sequencing) for details.

--- a/specification/wse/SPEC.md
+++ b/specification/wse/SPEC.md
@@ -128,7 +128,7 @@ The WebSocket Emulation protocol uses WebSocket protocol URIs, as defined by
 To establish an emulated WebSocket connection, a client makes an HTTP handshake request.
 
 * the HTTP handshake request uri scheme MUST be derived from the WebSocket URL by changing `ws` to `http`, or `wss` to `https`
-* the HTTP handshake request method SHOULD be `POST` but MAY be `GET`
+* the HTTP handshake request method MUST be `POST`
 * the HTTP handshake request uri path MUST be derived from the WebSocket URL by appending a suitable handshake encoding path 
   suffix which indicates the create encoding.
   * For connections allowing binary and text frames (mixed):
@@ -242,7 +242,8 @@ process the handshake request to generate a handshake response.
 If the server determines that any of the following conditions are not met by the HTTP handshake request, then the server MUST
 send an HTTP response with a `4xx` status code, such as `400 Bad Request`.
 
-* the HTTP handshake request method MUST be `POST` 
+* the HTTP handshake request method SHOULD be `POST`
+* for compatibility with existing clients that are not fully compliant with this specification, the HTTP handshake request method MAY be `GET`
 * the HTTP handshake request header `X-WebSocket-Version` MUST have the value `wseb-1.0`
 * the HTTP handshake request header `X-Sequence-No` MUST be a valid sequence number. Please see [Request Sequencing](#request-sequencing) for details.
 * the HTTP handshake request header `X-WebSocket-Protocol` is OPTIONAL, and when present indicates a list of alternative 

--- a/specification/wse/SPEC.md
+++ b/specification/wse/SPEC.md
@@ -116,7 +116,7 @@ These subprotocol names should follow the guidelines described by the WebSocket 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and 
 "OPTIONAL" in this document are to be interpreted as described in [[RFC 6455]][RFC6455].
 
-## WebSocket Emulatation URIs
+## WebSocket Emulation URIs
 
 The WebSocket Emulation protocol uses WebSocket protocol URIs, as defined by
 [RFC 6455, Section 3](https://tools.ietf.org/html/rfc6455#section-3).
@@ -128,7 +128,7 @@ The WebSocket Emulation protocol uses WebSocket protocol URIs, as defined by
 To establish an emulated WebSocket connection, a client makes an HTTP handshake request.
 
 * the HTTP handshake request uri scheme MUST be derived from the WebSocket URL by changing `ws` to `http`, or `wss` to `https`
-* the HTTP handshake request method MUST be `POST` 
+* the HTTP handshake request method SHOULD be `POST` but MAY be `GET`
 * the HTTP handshake request uri path MUST be derived from the WebSocket URL by appending a suitable handshake encoding path 
   suffix which indicates the create encoding.
   * For connections allowing binary and text frames (mixed):
@@ -156,7 +156,7 @@ WebSocket connection.
 Clients SHOULD send the `X-Accept-Commands` HTTP header with the value `ping` to indicate that both `PING` and `PONG` frames 
 are understood by the client.
 
-Clients MUST send an empty handshake request body.
+Clients SHOULD send an empty handshake request body.
 
 For example, given the WebSocket Emulation URL `ws://host.example.com:8080/path?query` and binary encoding.
 
@@ -289,7 +289,8 @@ original handshake request URL path.
 
 Once the emulated WebSocket connection is established, the client MUST send an HTTP request for downstream data
 transfer.
-* the HTTP downstream request method MUST be `GET` 
+* the HTTP downstream request method SHOULD be `GET`
+* clients unable to use `GET` MAY use `POST`, in which case the request body SHOULD be empty but MAY be non-empty
 * the HTTP downstream request `Origin` header MUST be present with the source origin for browser clients
 * Clients MUST send the `X-Sequence-No` HTTP header. Please see [Request Sequencing](#request-sequencing) for details.
 
@@ -527,7 +528,7 @@ initial downstream HTTP response is completed normally with a `RECONNECT` comman
 response body through any buffering proxy.
 
 Then, the response to the second downstream request either redirects the client to an encrypted location for secure streaming, 
-or fall back to long-polling as a last resort.
+or falls back to long-polling as a last resort.
 
 When long-polling, any frame sent to the client triggers a controlled reconnect in the same way as
 [Garbage Collection](#garbage-collection).  In this case, the `Content-Length` downstream HTTP response header SHOULD be

--- a/specification/wse/SPEC.md
+++ b/specification/wse/SPEC.md
@@ -290,8 +290,7 @@ original handshake request URL path.
 
 Once the emulated WebSocket connection is established, the client MUST send an HTTP request for downstream data
 transfer.
-* the HTTP downstream request method SHOULD be `GET`
-* clients unable to use `GET` MAY use `POST`, in which case the request body SHOULD be empty but MAY be non-empty
+* the HTTP downstream request method MUST be `GET`
 * the HTTP downstream request `Origin` header MUST be present with the source origin for browser clients
 * Clients MUST send the `X-Sequence-No` HTTP header. Please see [Request Sequencing](#request-sequencing) for details.
 
@@ -338,12 +337,14 @@ See [Text Encoding](#text-encoding) for details of processing a text HTTP downst
 
 See [Text Escaped Encoding](#text-escaped-encoding) for details of processing an escaped text HTTP downstream request.
 
-If the emulated WebSocket cannot be located for the HTTP downstream request path, then the server MUST generate an HTTP response
-with a `404 Not Found` status code.
+The Incoming downstream request is validated as follows:
 
-If `X-Sequence-No` header is missing in downstream request, then the server MUST generate an HTTP response with a `400 Bad Request` status code and fail the WSE connection.
-
-If the sequence number received in `X-Sequence-No` header is out of order or invalid, the server MUST generate an HTTP response with a `400 Bad Request` status code and fail the WSE connection. Please see [Request Sequencing](#request-sequencing) for details.
+* The request method SHOULD be `GET`. 
+* For compatibility with existing clients that are not fully compliant with this specification, the request method MAY be `POST` (with or without content, any content is ignored).
+* If the request method is neither `GET` nor `POST`, then the server MUST generate an HTTP response with a `400 Bad Request` status code and fail the WSE connection.
+* If the emulated WebSocket cannot be located for the HTTP downstream request path, then the server MUST generate an HTTP response with a `404 Not Found` status code.
+* If `X-Sequence-No` header is missing in downstream request, then the server MUST generate an HTTP response with a `400 Bad Request` status code and fail the WSE connection.
+* If the sequence number received in `X-Sequence-No` header is out of order or invalid, the server MUST generate an HTTP response with a `400 Bad Request` status code and fail the WSE connection. Please see [Request Sequencing](#request-sequencing) for details.
 
 If the `.ki` query parameter is present with value `p`, see [Buffering Proxies](#buffering-proxies) for further server 
 requirements when attaching the downstream.

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/downstream/binary/request.method.not.get.or.post/downstream.request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/downstream/binary/request.method.not.get.or.post/downstream.request.rpt
@@ -19,7 +19,7 @@ property sequence ${wse:randomInt(100)}
 connect http://localhost:8080/path/;e/cb?query
 connected
 
-write method "GET"
+write method "POST"
 write version "HTTP/1.1"
 write header host
 write header content-length
@@ -27,5 +27,25 @@ write header "X-WebSocket-Version" "wseb-1.0"
 write header "X-Sequence-No" ${wse:asString(sequence)}
 write close
 
-read status /4\d\d/ /.+/
+read status "201" /.+/
+read version "HTTP/1.1"
+read header "Content-Type" /text\/plain;charset=(?i)utf-8/
+
+read /(?<upstream>http:\/\/localhost:8080\/path\/.+)/ "\n"
+read /(?<downstream>http:\/\/localhost:8080\/path\/.+)/ "\n"
+read notify CREATED
 read closed
+
+# Downstream
+connect await CREATED
+connect ${downstream}
+connected
+
+write method "HEAD"
+write version "HTTP/1.1"
+write header host
+write header "X-Sequence-No" ${wse:asString(sequence + 1)}
+write header content-length
+write close
+
+read status /4\d\d/ /.+/

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/downstream/binary/request.method.not.get.or.post/downstream.response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/downstream/binary/request.method.not.get.or.post/downstream.response.rpt
@@ -36,7 +36,6 @@ write header content-length
 
 write ${upstream} "\n"
 write ${downstream} "\n"
-write notify CREATE_COMPLETED
 write close
 
 # Downstream
@@ -44,42 +43,11 @@ accept ${downstream}
 accepted
 connected
 
-read await CREATE_COMPLETED
-read method "GET"
+read method /(?!(GET|POST))/
 read version "HTTP/1.1"
-read header "Origin" "http://localhost:8080"
 read header "X-Sequence-No" ${wse:asString(sequence + 1)}
 read closed
 
-write status "200" "OK"
-write version "HTTP/1.1"
-write header "Content-Type" "application/octet-stream"
-write header "Connection" "close"
-write flush
-write notify SERVER_DOWNSTREAM_OPENED
-
-write await CLOSE_FRAME_RECEIVED
-write [0x01 0x30 0x32 0xFF]
-write [0x01 0x30 0x31 0xFF]
-write close
-
-# Upstream
-accept ${upstream}
-accepted
-connected
-
-read await SERVER_DOWNSTREAM_OPENED
-read method "POST"
-read version "HTTP/1.1"
-read header "Content-Type" "application/octet-stream"
-read header "X-Sequence-No" ${wse:asString(sequence + 1)}
-
-read [0x01 0x30 0x32 0xFF]
-read [0x01 0x30 0x31 0xFF]
-read notify CLOSE_FRAME_RECEIVED
-read closed
-
-write status "200" "OK"
-write version "HTTP/1.1"
+write status "400" "Bad Request" 
 write header content-length
 write close

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/downstream/binary/request.method.post.with.body/downstream.request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/downstream/binary/request.method.post.with.body/downstream.request.rpt
@@ -46,6 +46,34 @@ write version "HTTP/1.1"
 write header host
 write header "X-Sequence-No" ${wse:asString(sequence + 1)}
 write header content-length
+write ">|<"
 write close
 
-read status /4\d\d/ /.+/
+read status "200" /.+/
+read header "Content-Type" "application/octet-stream"
+read header "Connection" "close"
+read notify CLIENT_DOWNSTREAM_OPENED
+
+read [0x01 0x30 0x32 0xFF]
+read [0x01 0x30 0x31 0xFF]
+read closed
+
+# Upstream
+connect await CLIENT_DOWNSTREAM_OPENED
+connect ${upstream}
+connected
+
+write method "POST"
+write version "HTTP/1.1"
+write header host
+write header "Content-Type" "application/octet-stream"
+write header "X-Sequence-No" ${wse:asString(sequence + 1)}
+write header content-length
+
+write [0x01 0x30 0x32 0xFF]
+write [0x01 0x30 0x31 0xFF]
+write close
+
+read status "200" /.+/
+read version "HTTP/1.1"
+read closed

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/downstream/binary/request.method.post.with.body/downstream.response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/downstream/binary/request.method.post.with.body/downstream.response.rpt
@@ -43,11 +43,41 @@ accept ${downstream}
 accepted
 connected
 
-read method /(?!GET)/
+read method "POST"
 read version "HTTP/1.1"
 read header "X-Sequence-No" ${wse:asString(sequence + 1)}
+read /.+/
 read closed
 
-write status "400" "Bad Request" 
+write status "200" "OK"
+write version "HTTP/1.1"
+write header "Content-Type" "application/octet-stream"
+write header "Connection" "close"
+write flush
+write notify SERVER_DOWNSTREAM_OPENED
+
+write await CLOSE_FRAME_RECEIVED
+write [0x01 0x30 0x32 0xFF]
+write [0x01 0x30 0x31 0xFF]
+write close
+
+# Upstream
+accept ${upstream}
+accepted
+connected
+
+read await SERVER_DOWNSTREAM_OPENED
+read method "POST"
+read version "HTTP/1.1"
+read header "Content-Type" "application/octet-stream"
+read header "X-Sequence-No" ${wse:asString(sequence + 1)}
+
+read [0x01 0x30 0x32 0xFF]
+read [0x01 0x30 0x31 0xFF]
+read notify CLOSE_FRAME_RECEIVED
+read closed
+
+write status "200" "OK"
+write version "HTTP/1.1"
 write header content-length
 write close

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/downstream/binary/request.method.post/downstream.request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/downstream/binary/request.method.post/downstream.request.rpt
@@ -1,0 +1,78 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property sequence ${wse:randomInt(100)}
+
+connect http://localhost:8080/path/;e/cb?query
+connected
+
+write method "POST"
+write version "HTTP/1.1"
+write header host
+write header content-length
+write header "X-WebSocket-Version" "wseb-1.0"
+write header "X-Sequence-No" ${wse:asString(sequence)}
+write close
+
+read status "201" /.+/
+read version "HTTP/1.1"
+read header "Content-Type" /text\/plain;charset=(?i)utf-8/
+
+read /(?<upstream>http:\/\/localhost:8080\/path\/.+)/ "\n"
+read /(?<downstream>http:\/\/localhost:8080\/path\/.+)/ "\n"
+read notify CREATED
+read closed
+
+# Downstream
+connect await CREATED
+connect ${downstream}
+connected
+
+write method "POST"
+write version "HTTP/1.1"
+write header host
+write header "X-Sequence-No" ${wse:asString(sequence + 1)}
+write header content-length
+write close
+
+read status "200" /.+/
+read header "Content-Type" "application/octet-stream"
+read header "Connection" "close"
+read notify CLIENT_DOWNSTREAM_OPENED
+
+read [0x01 0x30 0x32 0xFF]
+read [0x01 0x30 0x31 0xFF]
+read closed
+
+# Upstream
+connect await CLIENT_DOWNSTREAM_OPENED
+connect ${upstream}
+connected
+
+write method "POST"
+write version "HTTP/1.1"
+write header host
+write header "Content-Type" "application/octet-stream"
+write header "X-Sequence-No" ${wse:asString(sequence + 1)}
+write header content-length
+
+write [0x01 0x30 0x32 0xFF]
+write [0x01 0x30 0x31 0xFF]
+write close
+
+read status "200" /.+/
+read version "HTTP/1.1"
+read closed

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/downstream/binary/request.method.post/downstream.response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/downstream/binary/request.method.post/downstream.response.rpt
@@ -36,7 +36,6 @@ write header content-length
 
 write ${upstream} "\n"
 write ${downstream} "\n"
-write notify CREATE_COMPLETED
 write close
 
 # Downstream
@@ -44,10 +43,8 @@ accept ${downstream}
 accepted
 connected
 
-read await CREATE_COMPLETED
-read method "GET"
+read method "POST"
 read version "HTTP/1.1"
-read header "Origin" "http://localhost:8080"
 read header "X-Sequence-No" ${wse:asString(sequence + 1)}
 read closed
 

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/opening/request.method.get/handshake.request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/opening/request.method.get/handshake.request.rpt
@@ -1,0 +1,35 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property sequence ${wse:randomInt(100)}
+
+connect http://localhost:8080/path/;e/cb?query
+connected
+
+write method "GET"
+write version "HTTP/1.1"
+write header host
+write header "X-WebSocket-Version" "wseb-1.0"
+write header "X-Sequence-No" ${wse:asString(sequence)}
+write close
+
+read status "201" /.+/
+read version "HTTP/1.1"
+read header "Content-Type" /text\/plain;charset=(?i)utf-8/
+
+read /http:\/\/localhost:8080\/path\/.+?\n/
+read /http:\/\/localhost:8080\/path\/.+?\n/
+read closed

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/opening/request.method.get/handshake.response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/opening/request.method.get/handshake.response.rpt
@@ -23,63 +23,18 @@ accept http://localhost:8080/path/;e/cb?query
 accepted
 connected
 
-read method "POST"
+read method "GET"
 read version "HTTP/1.1"
 read header "X-WebSocket-Version" "wseb-1.0"
 read header "X-Sequence-No" /(?<sequence>[0-9]{1,3})/
 read closed
 
+
 write status "201" "Created" 
 write version "HTTP/1.1"
-write header "Content-Type" "text/plain;charset=utf-8"
+write header "Content-Type" "text/plain;charset=UTF-8"
 write header content-length
 
 write ${upstream} "\n"
 write ${downstream} "\n"
-write notify CREATE_COMPLETED
-write close
-
-# Downstream
-accept ${downstream}
-accepted
-connected
-
-read await CREATE_COMPLETED
-read method "GET"
-read version "HTTP/1.1"
-read header "Origin" "http://localhost:8080"
-read header "X-Sequence-No" ${wse:asString(sequence + 1)}
-read closed
-
-write status "200" "OK"
-write version "HTTP/1.1"
-write header "Content-Type" "application/octet-stream"
-write header "Connection" "close"
-write flush
-write notify SERVER_DOWNSTREAM_OPENED
-
-write await CLOSE_FRAME_RECEIVED
-write [0x01 0x30 0x32 0xFF]
-write [0x01 0x30 0x31 0xFF]
-write close
-
-# Upstream
-accept ${upstream}
-accepted
-connected
-
-read await SERVER_DOWNSTREAM_OPENED
-read method "POST"
-read version "HTTP/1.1"
-read header "Content-Type" "application/octet-stream"
-read header "X-Sequence-No" ${wse:asString(sequence + 1)}
-
-read [0x01 0x30 0x32 0xFF]
-read [0x01 0x30 0x31 0xFF]
-read notify CLOSE_FRAME_RECEIVED
-read closed
-
-write status "200" "OK"
-write version "HTTP/1.1"
-write header content-length
 write close

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/opening/request.method.not.post.or.get/handshake.request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/opening/request.method.not.post.or.get/handshake.request.rpt
@@ -14,16 +14,18 @@
 # limitations under the License.
 #
 
-accept http://localhost:8080/path/;e/cb?query
-accepted
+property sequence ${wse:randomInt(100)}
+
+connect http://localhost:8080/path/;e/cb?query
 connected
 
-read method /(?!POST)/
-read version "HTTP/1.1"
-read header "X-WebSocket-Version" "wseb-1.0"
-read header "X-Sequence-No" /(?<sequence>[0-9]{1,3})/
-read closed
-
-write status "400" "Bad Request" 
+write method "HEAD"
+write version "HTTP/1.1"
+write header host
 write header content-length
+write header "X-WebSocket-Version" "wseb-1.0"
+write header "X-Sequence-No" ${wse:asString(sequence)}
 write close
+
+read status /4\d\d/ /.+/
+read closed

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/opening/request.method.not.post.or.get/handshake.response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/opening/request.method.not.post.or.get/handshake.response.rpt
@@ -1,0 +1,29 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+accept http://localhost:8080/path/;e/cb?query
+accepted
+connected
+
+read method /(?!(POST|GET))/
+read version "HTTP/1.1"
+read header "X-WebSocket-Version" "wseb-1.0"
+read header "X-Sequence-No" /(?<sequence>[0-9]{1,3})/
+read closed
+
+write status "400" "Bad Request" 
+write header content-length
+write close

--- a/specification/wse/src/test/java/org/kaazing/specification/wse/DownstreamIT.java
+++ b/specification/wse/src/test/java/org/kaazing/specification/wse/DownstreamIT.java
@@ -75,7 +75,8 @@ public class DownstreamIT {
     @Specification({
         "binary/request.method.post/downstream.request",
         "binary/request.method.post/downstream.response" })
-    public void shouldConnectWithDownstreamRequestMethodPost()
+    // Server only test. Spec compliant clients ALWAYS use GET.
+    public void serverShouldTolerateDownstreamRequestMethodPost()
             throws Exception {
         k3po.finish();
     }
@@ -84,7 +85,8 @@ public class DownstreamIT {
     @Specification({
         "binary/request.method.post.with.body/downstream.request",
         "binary/request.method.post.with.body/downstream.response" })
-    public void shouldConnectWithDownstreamRequestMethodPostWithBody()
+    // Server only test. Spec compliant clients ALWAYS use GET.
+    public void serverShouldTolerateDownstreamRequestMethodPostWithBody()
             throws Exception {
         k3po.finish();
     }

--- a/specification/wse/src/test/java/org/kaazing/specification/wse/DownstreamIT.java
+++ b/specification/wse/src/test/java/org/kaazing/specification/wse/DownstreamIT.java
@@ -64,9 +64,36 @@ public class DownstreamIT {
 
     @Test
     @Specification({
-        "binary/request.method.not.get/downstream.request",
-        "binary/request.method.not.get/downstream.response" })
-    public void shouldRespondWithBadRequestWhenBinaryDownstreamRequestMethodNotGet()
+        "binary/request.header.origin/downstream.request",
+        "binary/request.header.origin/downstream.response" })
+    public void shouldConnectWithDownstreamRequestOriginHeaderSet()
+            throws Exception {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "binary/request.method.post/downstream.request",
+        "binary/request.method.post/downstream.response" })
+    public void shouldConnectWithDownstreamRequestMethodPost()
+            throws Exception {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "binary/request.method.post.with.body/downstream.request",
+        "binary/request.method.post.with.body/downstream.response" })
+    public void shouldConnectWithDownstreamRequestMethodPostWithBody()
+            throws Exception {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "binary/request.method.not.get.or.post/downstream.request",
+        "binary/request.method.not.get.or.post/downstream.response" })
+    public void shouldRespondWithBadRequestWhenDownstreamRequestMethodNotGetOrPost()
             throws Exception {
         k3po.finish();
     }

--- a/specification/wse/src/test/java/org/kaazing/specification/wse/OpeningIT.java
+++ b/specification/wse/src/test/java/org/kaazing/specification/wse/OpeningIT.java
@@ -105,7 +105,8 @@ public class OpeningIT {
     @Specification({
         "request.method.get/handshake.request",
         "request.method.get/handshake.response" })
-    public void shouldEstablishConnectionWhenRequestMethodIsGet() throws Exception {
+    // Server only test. Spec compliant clients ALWAYS use POST.
+    public void serverShouldTolerateRequestMethodGet() throws Exception {
         k3po.finish();
     }
 

--- a/specification/wse/src/test/java/org/kaazing/specification/wse/OpeningIT.java
+++ b/specification/wse/src/test/java/org/kaazing/specification/wse/OpeningIT.java
@@ -103,9 +103,17 @@ public class OpeningIT {
 
     @Test
     @Specification({
-        "request.method.not.post/handshake.request",
-        "request.method.not.post/handshake.response" })
-    public void shouldFailHandshakeWhenRequestMethodNotPost() throws Exception {
+        "request.method.get/handshake.request",
+        "request.method.get/handshake.response" })
+    public void shouldEstablishConnectionWhenRequestMethodIsGet() throws Exception {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "request.method.not.post.or.get/handshake.request",
+        "request.method.not.post.or.get/handshake.response" })
+    public void shouldFailHandshakeWhenRequestMethodNotPostOrGet() throws Exception {
         k3po.finish();
     }
 

--- a/specification/wse/src/test/java/org/kaazing/specification/wse/OpeningIT.java
+++ b/specification/wse/src/test/java/org/kaazing/specification/wse/OpeningIT.java
@@ -78,7 +78,8 @@ public class OpeningIT {
     @Specification({
         "request.with.body/handshake.request",
         "request.with.body/handshake.response" })
-    public void shouldEstablishConnectionWithNonEmptyRequestBody()
+    // Server only test. Spec compliant clients ALWAYS use a POST request with an empty body.
+    public void serverShouldTolerateNonEmptyRequestBody()
             throws Exception {
         k3po.finish();
     }


### PR DESCRIPTION
… in the create request, allow GET for the create request, and allow POST for the downstream request. Made corresponding specification test changes. Also added missing test method shouldConnectWithDownstreamRequestOriginHeaderSet in DownstreamIT.

See #298 for details about why these changes are necessary.