### PR TITLE
Fixed wseb spec test script client.abruptly.closes.upstream/request 

### DIFF
--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/closing/client.abruptly.closes.upstream/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/closing/client.abruptly.closes.upstream/request.rpt
@@ -52,6 +52,8 @@ read status "200" /.+/
 read header "Content-Type" "application/octet-stream"
 read header "Connection" "close"
 
+read notify DOWNSTREAM_CONNECTED
+
 read await UPSTREAM_ABORT
 read [0x01 0x30 0x32 0xFF]
 read [0x01 0x30 0x31 0xFF]
@@ -60,7 +62,7 @@ read closed
 closed
 
 # Upstream
-connect await CREATED
+connect await DOWNSTREAM_CONNECTED
 connect ${upstream}
 connected
 


### PR DESCRIPTION
to use a barrier to guarantee predictable ordering of the downstream and upstream requests. This is needed to avoid sporadic failures in Gateway build due to downstream connection coming too late and resulting in a (correct) 404 response.