### PR TITLE
Adding some more negative tests for httpxe

### DIFF
--- a/specification/httpxe/SPEC.md
+++ b/specification/httpxe/SPEC.md
@@ -571,7 +571,7 @@ POST /path HTTP/1.1
 Host: target.example.com:80
 Origin: http://source.example.com:80
 ```
-If the authoritative source origin cannot be determined, then the server MUST response with status code `400 Bad Request`.
+If the authoritative source origin cannot be determined, then the server MUST responsd with 4xx status code (either `403 Forbidden` or `400 Bad Request`).
 
 ### Origin Query Parameter
 If the `.ko` query parameter is present and both the `Origin` and `X-Origin` headers are not present and the `Referer` header 

--- a/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.origin.request.using.referer/request.rpt
+++ b/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.origin.request.using.referer/request.rpt
@@ -1,0 +1,29 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect http://localhost:8000/path
+connected
+
+write method "POST"
+write version "HTTP/1.1"
+write header host
+write header "Referer" "http://localhost1:8000/different/path"
+write header "X-Origin" "http://source.example.com:80"
+write header content-length
+write flush
+
+# Referer's authority doesn't match Host header
+read status "403" /.*/

--- a/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.origin.request.using.referer/response.rpt
+++ b/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.origin.request.using.referer/response.rpt
@@ -1,0 +1,28 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+accept http://localhost:8000/path
+accepted
+connected
+
+read method "POST"
+read version "HTTP/1.1"
+read header "HOST" "localhost:8000"
+read header "Referer" "http://localhost1:8000/different/path"
+read header "X-Origin" "http://source.example.com:80"
+
+write status "403" "Forbidden"
+write close

--- a/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.encoded.request.header.1/request.rpt
+++ b/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.encoded.request.header.1/request.rpt
@@ -1,0 +1,29 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect http://localhost:8000/;post/path
+connected
+
+write method "POST"
+write version "HTTP/1.1"
+write header host
+write header "X-Origin" "http://source.example.com:80"
+write header "X-Origin-http%3A%2F%2Funknownsource.example.com%3A80" "http://source.example.com:80"
+write header content-length
+write flush
+
+# NO "X-Origin-http%3A%2F%2Fsource.example.com%3A80", instead "X-Origin-http%3A%2F%2Funknownsource.example.com%3A80"
+read status "403" /.*/

--- a/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.encoded.request.header.1/response.rpt
+++ b/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.encoded.request.header.1/response.rpt
@@ -1,0 +1,28 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+accept http://localhost:8000/;post/path
+accepted
+connected
+
+read method "POST"
+read version "HTTP/1.1"
+read header "HOST" "localhost:8000"
+read header "X-Origin" "http://source.example.com:80"
+read header "X-Origin-http%3A%2F%2Funknownsource.example.com%3A80" "http://source.example.com:80"
+
+write status "403" "Forbidden"
+write close

--- a/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.encoded.request.header.2/request.rpt
+++ b/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.encoded.request.header.2/request.rpt
@@ -1,0 +1,30 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect http://localhost:8000/;post/path
+connected
+
+write method "POST"
+write version "HTTP/1.1"
+write header host
+write header "X-Origin" "http://source.example.com:80"
+write header "X-Origin-http%3A%2F%2Fsource.example.com%3A80" "http://unknownsource.example.com:80"
+write header content-length
+write flush
+
+# "X-Origin-http%3A%2F%2Funknownsource.example.com%3A80" has "http://unknownsource.example.com:80"
+# instead of "http://source.example.com:80", hence 403
+read status "403" /.*/

--- a/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.encoded.request.header.2/response.rpt
+++ b/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.encoded.request.header.2/response.rpt
@@ -1,0 +1,28 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+accept http://localhost:8000/;post/path
+accepted
+connected
+
+read method "POST"
+read version "HTTP/1.1"
+read header "HOST" "localhost:8000"
+read header "X-Origin" "http://source.example.com:80"
+read header "X-Origin-http%3A%2F%2Fsource.example.com%3A80" "http://unknownsource.example.com:80"
+
+write status "403" "Forbidden"
+write close

--- a/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.encoded.request.header/request.rpt
+++ b/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.encoded.request.header/request.rpt
@@ -1,0 +1,28 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect http://localhost:8000/;post/path
+connected
+
+write method "POST"
+write version "HTTP/1.1"
+write header host
+write header "X-Origin" "http://source.example.com:80"
+write header content-length
+write flush
+
+# NO "X-Origin-http%3A%2F%2Fsource.example.com%3A80", hence 403
+read status "403" /.*/

--- a/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.encoded.request.header/response.rpt
+++ b/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.encoded.request.header/response.rpt
@@ -1,0 +1,28 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+accept http://localhost:8000/;post/path
+accepted
+connected
+
+read method "POST"
+read version "HTTP/1.1"
+read header "HOST" "localhost:8000"
+read header "X-Origin" "http://source.example.com:80"
+#read header "X-Origin-http%3A%2F%2Fsource.example.com%3A80" "http://source.example.com:80"
+
+write status "403" "Forbidden"
+write close

--- a/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.header.not.identical.to.origin.header/request.rpt
+++ b/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.header.not.identical.to.origin.header/request.rpt
@@ -1,0 +1,29 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect http://localhost:8000/path
+connected
+
+write method "POST"
+write version "HTTP/1.1"
+write header host
+write header "Origin" "http://localhost1:8000"
+write header "X-Origin" "http://source.example.com:80"
+write header content-length
+write flush
+
+# X-Origin is not identical to Origin, and Origin doesn't match Host header, hence 403
+read status "403" /.*/

--- a/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.header.not.identical.to.origin.header/response.rpt
+++ b/specification/httpxe/src/main/scripts/org/kaazing/specification/httpxe/origin/unauthorized.x.origin.header.not.identical.to.origin.header/response.rpt
@@ -1,0 +1,28 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+accept http://localhost:8000/path
+accepted
+connected
+
+read method "POST"
+read version "HTTP/1.1"
+read header "HOST" "localhost:8000"
+read header "Origin" "http://localhost1:8000"
+read header "X-Origin" "http://source.example.com:80"
+
+write status "403" "Forbidden"
+write close

--- a/specification/httpxe/src/test/java/org/kaazing/specification/httpxe/OriginSecurityIT.java
+++ b/specification/httpxe/src/test/java/org/kaazing/specification/httpxe/OriginSecurityIT.java
@@ -85,9 +85,25 @@ public class OriginSecurityIT {
 
     @Test
     @Specification({
+            "unauthorized.origin.request.using.referer/request",
+            "unauthorized.origin.request.using.referer/response"})
+    public void shouldFailWithOnlyRefererAndXoriginRequest() throws Exception {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "x.origin.header.not.identical.to.origin.header/request",
         "x.origin.header.not.identical.to.origin.header/response"})
     public void shouldPassWhenXoriginHeaderDiffersFromOriginHeader() throws Exception {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+            "unauthorized.x.origin.header.not.identical.to.origin.header/request",
+            "unauthorized.x.origin.header.not.identical.to.origin.header/response"})
+    public void shouldFailWhenXoriginHeaderDiffersFromOriginHeader() throws Exception {
         k3po.finish();
     }
 
@@ -104,6 +120,30 @@ public class OriginSecurityIT {
         "x.origin.encoded.request.header/request",
         "x.origin.encoded.request.header/response"})
     public void shouldPassWithEncodedXoriginRequest() throws Exception {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+            "unauthorized.x.origin.encoded.request.header/request",
+            "unauthorized.x.origin.encoded.request.header/response"})
+    public void shouldFailWithEncodedXoriginRequest() throws Exception {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+            "unauthorized.x.origin.encoded.request.header.1/request",
+            "unauthorized.x.origin.encoded.request.header.1/response"})
+    public void shouldFailWithEncodedXoriginRequest1() throws Exception {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+            "unauthorized.x.origin.encoded.request.header.2/request",
+            "unauthorized.x.origin.encoded.request.header.2/response"})
+    public void shouldFailWithEncodedXoriginRequest2() throws Exception {
         k3po.finish();
     }
 


### PR DESCRIPTION
Adding some more negative tests for:
* request method is path-encoded, Origin header not present, X-Origin present, X-Origin-http-xxx header not present or xxx part does not match X-Origin
* request method is path-encoded, Origin header not present, X-Origin present, X-Origin-http-xxx header xxx part does not match X-Origin
* X-Origin present and differs from the Origin header, and the request is not path-encoded, and the request is NOT determined to be a same-origin request by comparing value of the Origin header with the Host header
* X-Origin header is present and the Origin header is not present, and the request is not path-encoded, and the request is NOT determined to be a same-origin request by comparing value of the Referer header with the Host header

One thing different is that response status code is 403 (gateway does that too). It computes effective Origin header and runs through constraints.

It seems to me that we should separate out the functionality: method is path-encoded should mean to represent method. It shouldn't have any relation with cross origin security.