### PR TITLE
Caught exceptions that cause catostrophic failures in K3po and thus c…

### DIFF
--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/Robot.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/Robot.java
@@ -358,8 +358,12 @@ public class Robot {
                 server.setPipelineFactory(pipelineFactory(pipeline(closeOnExceptionHandler)));
             }
             for (ClientBootstrapResolver clientResolver : configuration.getClientResolvers()) {
-                ClientBootstrap client = clientResolver.resolve();
-                client.setPipelineFactory(pipelineFactory(pipeline(closeOnExceptionHandler)));
+                try {
+                    ClientBootstrap client = clientResolver.resolve();
+                    client.setPipelineFactory(pipelineFactory(pipeline(closeOnExceptionHandler)));
+                } catch (RuntimeException e) {
+                    LOGGER.warn("Exception caught while trying to stop client pipelies: " + e);
+                }
             }
 
             // remove each handler from the configuration pipelines

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/Robot.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/Robot.java
@@ -354,15 +354,19 @@ public class Robot {
 
             // clear out the pipelines for new connections to avoid impacting the observed script
             for (ServerBootstrapResolver serverResolver : configuration.getServerResolvers()) {
-                ServerBootstrap server = serverResolver.resolve();
-                server.setPipelineFactory(pipelineFactory(pipeline(closeOnExceptionHandler)));
+                try {
+                    ServerBootstrap server = serverResolver.resolve();
+                    server.setPipelineFactory(pipelineFactory(pipeline(closeOnExceptionHandler)));
+                } catch (RuntimeException e) {
+                    LOGGER.warn("Exception caught while trying to stop server pipelies", e);
+                }
             }
             for (ClientBootstrapResolver clientResolver : configuration.getClientResolvers()) {
                 try {
                     ClientBootstrap client = clientResolver.resolve();
                     client.setPipelineFactory(pipelineFactory(pipeline(closeOnExceptionHandler)));
                 } catch (RuntimeException e) {
-                    LOGGER.warn("Exception caught while trying to stop client pipelies: " + e);
+                    LOGGER.warn("Exception caught while trying to stop client pipelies", e);
                 }
             }
 

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/LocationResolver.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/LocationResolver.java
@@ -76,7 +76,7 @@ public class LocationResolver {
                     location = expression.getValue(environment);
                 }
             } catch (PropertyNotFoundException e) {
-                LOGGER.warn(e.getMessage());
+                LOGGER.warn(e.getMessage(), e);
                 location = null;
             }
 

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/LocationResolver.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/LocationResolver.java
@@ -18,11 +18,11 @@ package org.kaazing.k3po.driver.internal.resolver;
 import java.net.URI;
 
 import javax.el.ELContext;
+import javax.el.PropertyNotFoundException;
 import javax.el.ValueExpression;
 
 import org.jboss.netty.logging.InternalLogger;
 import org.jboss.netty.logging.InternalLoggerFactory;
-import org.kaazing.k3po.driver.internal.Robot;
 import org.kaazing.k3po.driver.internal.behavior.visitor.GenerateConfigurationVisitor;
 import org.kaazing.k3po.lang.internal.ast.value.AstLocation;
 import org.kaazing.k3po.lang.internal.ast.value.AstLocationExpression;
@@ -75,7 +75,7 @@ public class LocationResolver {
                     ValueExpression expression = value.getValue();
                     location = expression.getValue(environment);
                 }
-            } catch (javax.el.PropertyNotFoundException e) {
+            } catch (PropertyNotFoundException e) {
                 LOGGER.warn(e.getMessage());
                 location = null;
             }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/LocationResolver.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/LocationResolver.java
@@ -20,6 +20,9 @@ import java.net.URI;
 import javax.el.ELContext;
 import javax.el.ValueExpression;
 
+import org.jboss.netty.logging.InternalLogger;
+import org.jboss.netty.logging.InternalLoggerFactory;
+import org.kaazing.k3po.driver.internal.Robot;
 import org.kaazing.k3po.driver.internal.behavior.visitor.GenerateConfigurationVisitor;
 import org.kaazing.k3po.lang.internal.ast.value.AstLocation;
 import org.kaazing.k3po.lang.internal.ast.value.AstLocationExpression;
@@ -36,6 +39,7 @@ import org.kaazing.k3po.lang.internal.ast.value.AstLocationLiteral;
 public class LocationResolver {
 
     private static final LocationVisitorImpl VISITOR = new LocationVisitorImpl();
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(LocationResolver.class);
 
     private final AstLocation location;
     private final ELContext environment;
@@ -66,9 +70,14 @@ public class LocationResolver {
             Object location;
 
             // TODO: Remove when JUEL sync bug is fixed https://github.com/k3po/k3po/issues/147
-            synchronized (environment) {
-                ValueExpression expression = value.getValue();
-                location = expression.getValue(environment);
+            try {
+                synchronized (environment) {
+                    ValueExpression expression = value.getValue();
+                    location = expression.getValue(environment);
+                }
+            } catch (javax.el.PropertyNotFoundException e) {
+                LOGGER.warn(e.getMessage());
+                location = null;
             }
 
             if (location == null) {

--- a/junit/src/main/java/org/kaazing/k3po/junit/rules/ScriptRunner.java
+++ b/junit/src/main/java/org/kaazing/k3po/junit/rules/ScriptRunner.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.logging.Logger;
 
 import org.kaazing.k3po.control.internal.Control;
 import org.kaazing.k3po.control.internal.command.AbortCommand;

--- a/junit/src/main/java/org/kaazing/k3po/junit/rules/ScriptRunner.java
+++ b/junit/src/main/java/org/kaazing/k3po/junit/rules/ScriptRunner.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.logging.Logger;
 
 import org.kaazing.k3po.control.internal.Control;
 import org.kaazing.k3po.control.internal.command.AbortCommand;
@@ -260,7 +261,6 @@ final class ScriptRunner implements Callable<ScriptPair> {
 
         @Override
         public void initial() {
-            System.out.println("Hello");
             synchronized (this) {
                 this.state = NOTIFYING;
                 for (BarrierStateListener listener : stateListeners) {
@@ -323,7 +323,15 @@ final class ScriptRunner implements Callable<ScriptPair> {
             default:
                 throw new IllegalArgumentException("Unrecognized event kind: " + event.getKind());
             }
-        } finally {
+        } catch (Exception e) {
+            // TODO log this when we get a logger added to Junit, or remove need for this which always clean
+            // shutdown of k3po channels
+            e.printStackTrace();
+            // NOOP swallow exception as this is a clean up task that may fail in case setup didn't complete,
+            // expressions didn't get resolved. Etc.  This happens frequently when Junit Assume is used, as K3po
+            // will have inited the accept channels outside of the test method.
+        }
+        finally {
             controller.disconnect();
         }
     }


### PR DESCRIPTION
…ause junit to error out.  When in fact the Junit Assume or ignore can cause these in the first place.  It would be better to revisit all these places and ensure they can always clean up properly