### PR TITLE
Cleaned up imports

### DIFF
--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/event/AbstractEventHandler.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/event/AbstractEventHandler.java
@@ -44,7 +44,6 @@ import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelEvent;
 import org.jboss.netty.channel.ChannelException;
 import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.channel.ChannelFutureListener;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelStateEvent;
 import org.jboss.netty.channel.ChildChannelStateEvent;

--- a/examples/src/test/java/org/kaazing/k3po/examples/internal/BarriersIT.java
+++ b/examples/src/test/java/org/kaazing/k3po/examples/internal/BarriersIT.java
@@ -30,7 +30,7 @@ public class BarriersIT {
 
     private final K3poRule k3po = new K3poRule();
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+    private final TestRule timeout = new DisableOnDebug(new Timeout(20, SECONDS));
 
     @Rule
     public final TestRule chain = RuleChain.outerRule(k3po).around(timeout);

--- a/examples/src/test/java/org/kaazing/k3po/examples/internal/PropertyOverrideIT.java
+++ b/examples/src/test/java/org/kaazing/k3po/examples/internal/PropertyOverrideIT.java
@@ -38,7 +38,7 @@ public class PropertyOverrideIT {
 
     private final K3poRule k3po = new K3poRule().scriptProperty("RESPONSE 'Let\\'s take a selfie'");
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+    private final TestRule timeout = new DisableOnDebug(new Timeout(20, SECONDS));
 
     @Rule
     public final TestRule chain = RuleChain.outerRule(k3po).around(timeout);

--- a/examples/src/test/java/org/kaazing/k3po/examples/internal/TcpClientIT.java
+++ b/examples/src/test/java/org/kaazing/k3po/examples/internal/TcpClientIT.java
@@ -37,7 +37,7 @@ public class TcpClientIT {
 
     private final K3poRule k3po = new K3poRule();
 
-    private final TestRule timeout = new DisableOnDebug(new Timeout(5, SECONDS));
+    private final TestRule timeout = new DisableOnDebug(new Timeout(20, SECONDS));
 
     @Rule
     public final TestRule chain = outerRule(k3po).around(timeout);

--- a/junit/src/main/java/org/kaazing/k3po/junit/rules/ScriptRunner.java
+++ b/junit/src/main/java/org/kaazing/k3po/junit/rules/ScriptRunner.java
@@ -320,7 +320,14 @@ final class ScriptRunner implements Callable<ScriptPair> {
     public void dispose() throws Exception {
         try {
             controller.dispose();
-            CommandEvent event = controller.readEvent();
+
+            CommandEvent event = null;
+            do {
+                event = controller.readEvent();
+                // finished may arrive if there was an abort, in which
+                // case we allow 5 seconds for a finished and then send
+                // dispose.  Sometimes the finished still comes
+            } while (event.getKind() == CommandEvent.Kind.FINISHED);
 
             // ensure it is the correct event
             switch (event.getKind()) {

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.pong/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.pong/request.rpt
@@ -48,14 +48,6 @@ write header "X-Sequence-No" ${wse:asString(sequence + 1)}
 write header content-length
 write close
 
-read status "200" /.+/
-read header "Content-Type" "application/octet-stream"
-read header "Connection" "close"
-
-read [0x01 0x30 0x32 0xFF]
-read [0x01 0x30 0x31 0xFF]
-read closed
-
 # Upstream
 connect await CREATED
 connect ${upstream}

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.pong/response.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.pong/response.rpt
@@ -48,18 +48,6 @@ read version "HTTP/1.1"
 read header "X-Sequence-No" ${wse:asString(sequence + 1)}
 read closed
 
-write status "200" "OK"
-write version "HTTP/1.1"
-write header "Content-Type" "application/octet-stream"
-write header "Connection" "close"
-write flush
-
-write await PONG_RECEIVED
-write [0x01 0x30 0x32 0xFF]
-write [0x01 0x30 0x31 0xFF]
-write close
-
-
 # Upstream
 accept ${upstream}
 accepted


### PR DESCRIPTION
- Cleaned up imports
- Catched error condition where waiting for an ABORT timeout may hit NPE on unexpected FINISHED event
- Removed over specified portion of script in WSE where invalid upstream may cause downstream not to get established successfully
