### PR TITLE
fix httpx k3po scripts masking

### DIFF
--- a/specification/httpx/src/main/scripts/org/kaazing/specification/httpx/extended/client.sends.message.between.opening.and.extended.handshake/request.rpt
+++ b/specification/httpx/src/main/scripts/org/kaazing/specification/httpx/extended/client.sends.message.between.opening.and.extended.handshake/request.rpt
@@ -36,14 +36,23 @@ read header "Sec-WebSocket-Protocol" "x-kaazing-handshake"
 read header "Server" /.+/
 read header "Date" /.+/
 
-write [0x82 0x05] ${writeMask}
+write [0x82 0x85] ${writeMask}
 write option mask ${writeMask}
 write "Hello"
 write option mask [0x00 0x00 0x00 0x00]
 
-read [0x88 0x02 0x03 0xe8]
+# 400 Bad Request
+read [0x82 0x7E 0x00 0xAD]
+read "HTTP/1.1 400 Bad Request\r\n"
+read "Content-Type: text/html\r\n"
+read /Date:.+\r\n/
+read /Content-Length: \d+\r\n/
+read "\r\n"
+read "<html><head></head><body><h1>400 Bad Request</h1></body></html>"
 
-write [0x88 0x02] ${writeMask}
+write [0x88 0x82] ${writeMask}
 write option mask ${writeMask}
 write [0x03 0xe8]
 write option mask [0x00 0x00 0x00 0x00]
+
+read [0x88 0x02 0x03 0xe8]

--- a/specification/httpx/src/main/scripts/org/kaazing/specification/httpx/extended/client.sends.message.between.opening.and.extended.handshake/response.rpt
+++ b/specification/httpx/src/main/scripts/org/kaazing/specification/httpx/extended/client.sends.message.between.opening.and.extended.handshake/response.rpt
@@ -37,16 +37,24 @@ write header "Server" "Kaazing Gateway"
 write header "Date" ${httpx:getDate()}
 write flush
 
-read [0x82 0x05]
+read [0x82 0x85]
 read [(:maskingKey){4}]
 read option mask ${writeMask}
 read "Hello"
 read option mask [0x00 0x00 0x00 0x00]
 
-write [0x88 0x02 0x03 0xe8]
+write [0x82 0x7E 0x00 0xAD]
+write "HTTP/1.1 400 Bad Request\r\n"
+write "Content-Type: text/html\r\n"
+write "Date: " ${httpx:getDate()} "\r\n"
+write "Content-Length: 63\r\n"
+write "\r\n"
+write "<html><head></head><body><h1>400 Bad Request</h1></body></html>"
 
-read [0x88 0x02]
+read [0x88 0x82]
 read [(:maskingKey){4}]
 read option mask ${maskingKey}
 read [0x03 0xe8]
 read option mask [0x00 0x00 0x00 0x00]
+
+write [0x88 0x02 0x03 0xe8]


### PR DESCRIPTION
@dpwspoon While investigating ticket [434](https://github.com/kaazing/tickets/issues/434), I realized that the k3po scripts in scenario "client.sends.message.between.opening.and.extended.handshake" were wrong, because the client was sending unmasked frames, which the server should have been rejecting.
I modified the scripts for the masking issue, but I also changed the server response to match the current behavior of the gateway.
The httpx spec doesn't seem clear in this aspect, so I'm not sure which is the intended response. After detecting that the client has sent a different WS frame than the extended handshake request, should the server respond with a WS frame containing an encapsulated 400 Bad Request HTTP response? Or should it send a WS close frame?
Thanks!