### PR TITLE
Wse Upstream and downstream connects are racy

### DIFF
--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.ping/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.ping/request.rpt
@@ -51,13 +51,14 @@ write close
 read status "200" /.+/
 read header "Content-Type" "application/octet-stream"
 read header "Connection" "close"
+read notify DOWN_STREAM_CONNECTED
 
 read [0x01 0x30 0x32 0xFF]
 read [0x01 0x30 0x31 0xFF]
 read closed
 
 # Upstream
-connect await CREATED
+connect await DOWN_STREAM_CONNECTED
 connect ${upstream}
 connected
 

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.ping/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.ping/request.rpt
@@ -51,14 +51,14 @@ write close
 read status "200" /.+/
 read header "Content-Type" "application/octet-stream"
 read header "Connection" "close"
-read notify DOWN_STREAM_CONNECTED
+read notify DOWNSTREAM_CONNECTED
 
 read [0x01 0x30 0x32 0xFF]
 read [0x01 0x30 0x31 0xFF]
 read closed
 
 # Upstream
-connect await DOWN_STREAM_CONNECTED
+connect await DOWNSTREAM_CONNECTED
 connect ${upstream}
 connected
 

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.pong/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.pong/request.rpt
@@ -51,13 +51,14 @@ write close
 read status "200" /.+/
 read header "Content-Type" "application/octet-stream"
 read header "Connection" "close"
+read notify DOWN_STREAM_CONNECTED
 
 read [0x01 0x30 0x32 0xFF]
 read [0x01 0x30 0x31 0xFF]
 read closed
 
 # Upstream
-connect await CREATED
+connect await DOWN_STREAM_CONNECTED
 connect ${upstream}
 connected
 

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.pong/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/control/client.send.unexpected.pong/request.rpt
@@ -51,14 +51,14 @@ write close
 read status "200" /.+/
 read header "Content-Type" "application/octet-stream"
 read header "Connection" "close"
-read notify DOWN_STREAM_CONNECTED
+read notify DOWNSTREAM_CONNECTED
 
 read [0x01 0x30 0x32 0xFF]
 read [0x01 0x30 0x31 0xFF]
 read closed
 
 # Upstream
-connect await DOWN_STREAM_CONNECTED
+connect await DOWNSTREAM_CONNECTED
 connect ${upstream}
 connected
 

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/client.send.text.invalid.utf8/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/client.send.text.invalid.utf8/request.rpt
@@ -52,14 +52,14 @@ write close
 read status "200" /.+/
 read header "Content-Type" "application/octet-stream"
 read header "Connection" "close"
-read notify DOWN_STREAM_CONNECTED
+read notify DOWNSTREAM_CONNECTED
 
 read [0x01 0x30 0x32 0xFF]
 read [0x01 0x30 0x31 0xFF]
 read closed
 
 # Upstream
-connect await DOWN_STREAM_CONNECTED
+connect await DOWNSTREAM_CONNECTED
 connect ${upstream}
 connected
 

--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/client.send.text.invalid.utf8/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/client.send.text.invalid.utf8/request.rpt
@@ -52,13 +52,14 @@ write close
 read status "200" /.+/
 read header "Content-Type" "application/octet-stream"
 read header "Connection" "close"
+read notify DOWN_STREAM_CONNECTED
 
 read [0x01 0x30 0x32 0xFF]
 read [0x01 0x30 0x31 0xFF]
 read closed
 
 # Upstream
-connect await CREATED
+connect await DOWN_STREAM_CONNECTED
 connect ${upstream}
 connected
 


### PR DESCRIPTION
Wse Upstream and downstream connects are racy :
case 1: If upstream succeeds first and sends invalid data, the wse session gets closed. The downstream request gets 404
case 2: If downstream succeeds first, everything goes fine

Now it uses barriers to sequence upstream and downstream connects