### PR TITLE
There is race between downstream and upstream connects :

### DIFF
--- a/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/client.send.text.delimited.invalid.utf8/request.rpt
+++ b/specification/wse/src/main/scripts/org/kaazing/specification/wse/data/client.send.text.delimited.invalid.utf8/request.rpt
@@ -52,13 +52,14 @@ write close
 read status "200" /.+/
 read header "Content-Type" "application/octet-stream"
 read header "Connection" "close"
+read notify DOWNSTREAM_CONNECTED
 
 read [0x01 0x30 0x32 0xFF]
 read [0x01 0x30 0x31 0xFF]
 read closed
 
 # Upstream
-connect await CREATED
+connect await DOWNSTREAM_CONNECTED
 connect ${upstream}
 connected
 


### PR DESCRIPTION
There is race between downstream and upstream connects :

1. If upstream connects first and sends invalid request, the wseb session would be
closed. And the upstream connect would return 404
2. If the downstream connects first, the current script works
Now using barriers to fix the case 1