### PR TITLE
update message to work around HTTP method validation

### DIFF
--- a/specification/httpx/src/main/scripts/org/kaazing/specification/httpx/extended/client.sends.message.between.opening.and.extended.handshake/request.rpt
+++ b/specification/httpx/src/main/scripts/org/kaazing/specification/httpx/extended/client.sends.message.between.opening.and.extended.handshake/request.rpt
@@ -38,21 +38,12 @@ read header "Date" /.+/
 
 write [0x82 0x85] ${writeMask}
 write option mask ${writeMask}
-write "Hello"
+write "World"
 write option mask [0x00 0x00 0x00 0x00]
 
-# 400 Bad Request
-read [0x82 0x7E 0x00 0xAD]
-read "HTTP/1.1 400 Bad Request\r\n"
-read "Content-Type: text/html\r\n"
-read /Date:.+\r\n/
-read /Content-Length: \d+\r\n/
-read "\r\n"
-read "<html><head></head><body><h1>400 Bad Request</h1></body></html>"
+read [0x88 0x02 0x03 0xe8]
 
 write [0x88 0x82] ${writeMask}
 write option mask ${writeMask}
 write [0x03 0xe8]
 write option mask [0x00 0x00 0x00 0x00]
-
-read [0x88 0x02 0x03 0xe8]

--- a/specification/httpx/src/main/scripts/org/kaazing/specification/httpx/extended/client.sends.message.between.opening.and.extended.handshake/response.rpt
+++ b/specification/httpx/src/main/scripts/org/kaazing/specification/httpx/extended/client.sends.message.between.opening.and.extended.handshake/response.rpt
@@ -40,21 +40,13 @@ write flush
 read [0x82 0x85]
 read [(:maskingKey){4}]
 read option mask ${writeMask}
-read "Hello"
+read "World"
 read option mask [0x00 0x00 0x00 0x00]
 
-write [0x82 0x7E 0x00 0xAD]
-write "HTTP/1.1 400 Bad Request\r\n"
-write "Content-Type: text/html\r\n"
-write "Date: " ${httpx:getDate()} "\r\n"
-write "Content-Length: 63\r\n"
-write "\r\n"
-write "<html><head></head><body><h1>400 Bad Request</h1></body></html>"
+write [0x88 0x02 0x03 0xe8]
 
 read [0x88 0x82]
 read [(:maskingKey){4}]
 read option mask ${maskingKey}
 read [0x03 0xe8]
 read option mask [0x00 0x00 0x00 0x00]
-
-write [0x88 0x02 0x03 0xe8]


### PR DESCRIPTION
Update the sent message to start with a letter other than ones of valid
HTTP methods to bypass gateway validation. In a real scenario, the
request would time-out.