### PR TITLE
K3po driver fixes according to new specs + some additional fixes

### DIFF
--- a/control/src/main/java/org/kaazing/k3po/control/internal/Control.java
+++ b/control/src/main/java/org/kaazing/k3po/control/internal/Control.java
@@ -86,8 +86,11 @@ public final class Control {
      * @throws Exception if fails to connect.
      */
     public void connect() throws Exception {
-        connection = location.openConnection();
-        connection.connect();
+        // connection must be null if the connection failed
+        URLConnection newConnection = location.openConnection();
+        newConnection.connect();
+        connection = newConnection;
+        
         InputStream bytesIn = connection.getInputStream();
         CharsetDecoder decoder = UTF_8.newDecoder();
         textIn = new BufferedReader(new InputStreamReader(bytesIn, decoder));
@@ -203,6 +206,10 @@ public final class Control {
         if (connection == null) {
             throw new IllegalStateException("Not connected");
         }
+    }
+    
+    public boolean isConnected() {
+        return connection != null;
     }
 
     private void writeCommand(PrepareCommand prepare) throws Exception {
@@ -466,7 +473,7 @@ public final class Control {
         this.writeCommand(notifyCommand);
     }
 
-    public void await(String barrierName) throws Exception {
+    public void sendAwaitBarrier(String barrierName) throws Exception {
         final AwaitCommand awaitCommand = new AwaitCommand();
         awaitCommand.setBarrier(barrierName);
         this.writeCommand(awaitCommand);

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlDecoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlDecoder.java
@@ -71,7 +71,7 @@ public class ControlDecoder extends ReplayingDecoder<ControlDecoder.State> {
 
         switch (state) {
         case READ_INITIAL: {
-            String initialLine = readLine(buffer, maxInitialLineLength);
+            String initialLine = readLine(buffer, maxInitialLineLength, "Initial line too long");
             if (initialLine != null) {
                 message = createMessage(initialLine);
                 contentLength = 0;
@@ -100,34 +100,17 @@ public class ControlDecoder extends ReplayingDecoder<ControlDecoder.State> {
         }
     }
 
-    private static String readLine(ChannelBuffer buffer, int maxLineLength) {
-
-        int readableBytes = buffer.readableBytes();
-        if (readableBytes == 0) {
-            return null;
+    private String readLine(ChannelBuffer buffer, int maxLength, String errorMessage) {
+        StringBuilder sb = new StringBuilder();
+        byte b = buffer.readByte();
+        while (b != (byte) 0x0a && sb.length() < maxLength) {
+            sb.append((char) b);
+            b = buffer.readByte();
         }
-
-        int readerIndex = buffer.readerIndex();
-
-        int endOfLineAt = buffer.indexOf(readerIndex, readerIndex + Math.min(readableBytes, maxLineLength), (byte) 0x0a);
-
-        // end-of-line not found
-        if (endOfLineAt == -1) {
-            if (readableBytes >= maxLineLength) {
-                throw new IllegalArgumentException("Initial line too long");
-            }
-            return null;
-        }
-
-        // end-of-line found
-        StringBuilder sb = new StringBuilder(endOfLineAt);
-        for (int i = readerIndex; i < endOfLineAt; i++) {
-            sb.append((char) buffer.readByte());
-        }
-
-        byte endOfLine = buffer.readByte();
-        assert endOfLine == 0x0a;
-
+        
+        if (sb.length() >= maxLength)
+            throw new IllegalArgumentException(errorMessage);
+        
         return sb.toString();
     }
 
@@ -153,29 +136,9 @@ public class ControlDecoder extends ReplayingDecoder<ControlDecoder.State> {
     }
 
     private State readHeader(ChannelBuffer buffer) {
+        String line = readLine(buffer, maxHeaderLineLength, "Header line too long");
 
-        int readableBytes = buffer.readableBytes();
-        if (readableBytes == 0) {
-            return null;
-        }
-
-        int endOfLineSearchFrom = buffer.readerIndex();
-        // int endOfLineSearchTo = endOfLineSearchFrom + Math.min(readableBytes, maxHeaderLineLength);
-        int endOfLineSearchTo = Math.min(readableBytes, maxHeaderLineLength);
-        int endOfLineAt = buffer.indexOf(endOfLineSearchFrom, endOfLineSearchTo + 1, (byte) 0x0a);
-
-        // end-of-line not found
-        if (endOfLineAt == -1) {
-            if (readableBytes >= maxHeaderLineLength) {
-                throw new IllegalArgumentException("Header line too long");
-            }
-            return null;
-        }
-
-        if (endOfLineAt == endOfLineSearchFrom) {
-            byte endOfLine = buffer.readByte();
-            assert endOfLine == 0x0a;
-
+        if (line.length() == 0) {
             if (contentLength == 0) {
                 return State.READ_INITIAL;
             }
@@ -191,11 +154,7 @@ public class ControlDecoder extends ReplayingDecoder<ControlDecoder.State> {
             }
         }
 
-        // end-of-line found
-        int colonSearchFrom = buffer.readerIndex();
-        // int colonSearchTo = colonSearchFrom + Math.min(readableBytes, endOfLineAt);
-        int colonSearchTo = Math.min(readableBytes, endOfLineAt);
-        int colonAt = buffer.indexOf(colonSearchFrom, colonSearchTo + 1, (byte) 0x3a);
+        int colonAt = line.indexOf(":");
 
         // colon not found
         if (colonAt == -1) {
@@ -203,22 +162,9 @@ public class ControlDecoder extends ReplayingDecoder<ControlDecoder.State> {
         }
 
         // colon found
-        int headerNameLength = colonAt - colonSearchFrom;
-        StringBuilder headerNameBuilder = new StringBuilder(headerNameLength);
-        for (int i = 0; i < headerNameLength; i++) {
-            headerNameBuilder.append((char) buffer.readByte());
-        }
-        String headerName = headerNameBuilder.toString();
+        String headerName = line.substring(0, colonAt);
 
-        byte colon = buffer.readByte();
-        assert colon == 0x3a;
-
-        int headerValueLength = endOfLineAt - colonAt - 1;
-        StringBuilder headerValueBuilder = new StringBuilder(headerValueLength);
-        for (int i = 0; i < headerValueLength; i++) {
-            headerValueBuilder.append((char) buffer.readByte());
-        }
-        String headerValue = headerValueBuilder.toString();
+        String headerValue = line.substring(colonAt + 1);
 
         // add kind-specific headers
         switch (message.getKind()) {
@@ -274,8 +220,6 @@ public class ControlDecoder extends ReplayingDecoder<ControlDecoder.State> {
             break;
         }
 
-        byte endOfLine = buffer.readByte();
-        assert endOfLine == 0x0a;
         return State.READ_HEADER;
     }
 
@@ -283,11 +227,8 @@ public class ControlDecoder extends ReplayingDecoder<ControlDecoder.State> {
 
         assert contentLength > 0;
 
-        if (buffer.readableBytes() < contentLength) {
-            return State.READ_CONTENT;
-        }
-
         String content = buffer.readBytes(contentLength).toString(UTF_8);
+
         switch (message.getKind()) {
         case PREPARE:
             PrepareMessage prepareMessage = (PrepareMessage) message;

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlDecoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlDecoder.java
@@ -109,7 +109,7 @@ public class ControlDecoder extends ReplayingDecoder<ControlDecoder.State> {
 
         int readerIndex = buffer.readerIndex();
 
-        int endOfLineAt = buffer.indexOf(readerIndex, Math.min(readableBytes, maxLineLength) + 1, (byte) 0x0a);
+        int endOfLineAt = buffer.indexOf(readerIndex, readerIndex + Math.min(readableBytes, maxLineLength), (byte) 0x0a);
 
         // end-of-line not found
         if (endOfLineAt == -1) {

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlDecoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlDecoder.java
@@ -107,10 +107,10 @@ public class ControlDecoder extends ReplayingDecoder<ControlDecoder.State> {
             sb.append((char) b);
             b = buffer.readByte();
         }
-        
+
         if (sb.length() >= maxLength)
             throw new IllegalArgumentException(errorMessage);
-        
+
         return sb.toString();
     }
 

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlServerHandler.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlServerHandler.java
@@ -417,9 +417,6 @@ public class ControlServerHandler extends ControlUpstreamHandler {
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
                 if (oneTimeOnly.compareAndSet(false, true)) {
-//                    for (CountDownLatch latch : notifiedLatches) {
-//                        latch.await();
-//                    }
                     sendFinishedMessage(ctx);
                 }
             }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlUpstreamHandler.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlUpstreamHandler.java
@@ -85,7 +85,6 @@ public class ControlUpstreamHandler extends SimpleChannelUpstreamHandler {
         String msg = "Control channel caught exception event: ";
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(msg, e.getCause());
-            e.getCause().printStackTrace();
         } else {
             LOGGER.info(msg + e.getCause());
         }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlUpstreamHandler.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/control/handler/ControlUpstreamHandler.java
@@ -85,6 +85,7 @@ public class ControlUpstreamHandler extends SimpleChannelUpstreamHandler {
         String msg = "Control channel caught exception event: ";
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(msg, e.getCause());
+            e.getCause().printStackTrace();
         } else {
             LOGGER.info(msg + e.getCause());
         }

--- a/junit/src/main/java/org/kaazing/k3po/junit/rules/K3poRule.java
+++ b/junit/src/main/java/org/kaazing/k3po/junit/rules/K3poRule.java
@@ -83,6 +83,11 @@ public class K3poRule extends Verifier {
         latch = new Latch();
         classOverriddenProperties = new ArrayList<>();
         packagePathsByName = new HashMap<>();
+        
+        // There were situations where the interrupted status was set to true from the previous test.
+        // Check and clear the interrupted status from the thread
+        if (Thread.interrupted())
+            System.out.println("Warning - thread had interrupted status = true before test start");
     }
 
     /**

--- a/junit/src/main/java/org/kaazing/k3po/junit/rules/Latch.java
+++ b/junit/src/main/java/org/kaazing/k3po/junit/rules/Latch.java
@@ -139,9 +139,10 @@ class Latch {
 
     void notifyException(Exception exception) {
         this.exception = exception;
-        prepared.countDown();
-        startable.countDown();
-        finished.countDown();
+        // Commented because of issue https://github.com/k3po/k3po/issues/391
+//        prepared.countDown();
+//        startable.countDown();
+//        finished.countDown();
         if (testThread != null) {
             testThread.interrupt();
         }

--- a/junit/src/main/java/org/kaazing/k3po/junit/rules/Latch.java
+++ b/junit/src/main/java/org/kaazing/k3po/junit/rules/Latch.java
@@ -24,7 +24,7 @@ class Latch {
     private volatile State state;
     private volatile Exception exception;
 
-    private final CountDownLatch prepared;
+	private final CountDownLatch prepared;
     private final CountDownLatch startable;
     private final CountDownLatch finished;
     private final CountDownLatch disposed;
@@ -158,4 +158,7 @@ class Latch {
         disposed.countDown();
     }
 
+    public Exception getException() {
+		return exception;
+	}
 }

--- a/junit/src/main/java/org/kaazing/k3po/junit/rules/Latch.java
+++ b/junit/src/main/java/org/kaazing/k3po/junit/rules/Latch.java
@@ -24,10 +24,9 @@ class Latch {
     private volatile State state;
     private volatile Exception exception;
 
-	private final CountDownLatch prepared;
+    private final CountDownLatch prepared;
     private final CountDownLatch startable;
     private final CountDownLatch finished;
-    private final CountDownLatch disposed;
     private volatile Thread testThread;
 
     Latch() {
@@ -36,7 +35,6 @@ class Latch {
         prepared = new CountDownLatch(1);
         startable = new CountDownLatch(1);
         finished = new CountDownLatch(1);
-        disposed = new CountDownLatch(1);
     }
 
     void notifyPrepared() {
@@ -122,13 +120,6 @@ class Latch {
         finished.await();
     }
 
-    void awaitDisposed() throws Exception {
-        disposed.await();
-        if (exception != null) {
-            throw exception;
-        }
-    }
-
     boolean isFinished() {
         return finished.getCount() == 0L;
     }
@@ -153,10 +144,6 @@ class Latch {
         if (this.exception != null) {
             testThread.interrupt();
         }
-    }
-
-    public void notifyDisposed() {
-        disposed.countDown();
     }
 
     public Exception getException() {

--- a/junit/src/main/java/org/kaazing/k3po/junit/rules/ScriptRunner.java
+++ b/junit/src/main/java/org/kaazing/k3po/junit/rules/ScriptRunner.java
@@ -209,7 +209,7 @@ final class ScriptRunner implements Callable<ScriptPair> {
 
         });
         try {
-            controller.await(barrierName);
+            controller.sendAwaitBarrier(barrierName);
         } catch (Exception e) {
             latch.notifyException(e);
         }
@@ -319,6 +319,10 @@ final class ScriptRunner implements Callable<ScriptPair> {
 
     public void dispose() throws Exception {
         try {
+            // if called when there was a problem connecting to the driver, just skip it
+            if (! controller.isConnected())
+                return;
+            
             controller.dispose();
             
             // avoid getting blocked forever if the server is stuck

--- a/junit/src/main/java/org/kaazing/k3po/junit/rules/ScriptRunner.java
+++ b/junit/src/main/java/org/kaazing/k3po/junit/rules/ScriptRunner.java
@@ -17,15 +17,11 @@ package org.kaazing.k3po.junit.rules;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.kaazing.k3po.junit.rules.ScriptRunner.BarrierState.INITIAL;
-import static org.kaazing.k3po.junit.rules.ScriptRunner.BarrierState.NOTIFIED;
-import static org.kaazing.k3po.junit.rules.ScriptRunner.BarrierState.NOTIFYING;
 
 import java.lang.management.ManagementFactory;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +46,7 @@ final class ScriptRunner implements Callable<ScriptPair> {
     private final Latch latch;
 
     private volatile boolean abortScheduled;
-    private volatile Map<String, BarrierStateMachine> barriers;
+    private volatile Map<String, CountDownLatch> barriers;
     private final List<String> overridenScriptProperties;
     private static final int DISPOSE_TIMEOUT = isDebugging() ? 0: 5000;
 
@@ -67,7 +63,7 @@ final class ScriptRunner implements Callable<ScriptPair> {
         this.controller = new Control(controlURL);
         this.names = names;
         this.latch = latch;
-        this.barriers = new HashMap<String, ScriptRunner.BarrierStateMachine>();
+        this.barriers = new HashMap<String, CountDownLatch>();
         this.overridenScriptProperties = overridenScriptProperties;
     }
 
@@ -115,7 +111,7 @@ final class ScriptRunner implements Callable<ScriptPair> {
                         PreparedEvent prepared = (PreparedEvent) event;
                         expectedScript = prepared.getScript();
                         for (String barrier : prepared.getBarriers()) {
-                            barriers.put(barrier, new BarrierStateMachine());
+                            barriers.put(barrier, new CountDownLatch(1));
                         }
 
                         // notify script is prepared
@@ -138,8 +134,8 @@ final class ScriptRunner implements Callable<ScriptPair> {
                     case NOTIFIED:
                         NotifiedEvent notifiedEvent = (NotifiedEvent) event;
                         String barrier = notifiedEvent.getBarrier();
-                        BarrierStateMachine stateMachine = barriers.get(barrier);
-                        stateMachine.notified();
+                        CountDownLatch latch = barriers.get(barrier);
+                        latch.countDown();
                         break;
                     case ERROR:
                         ErrorEvent error = (ErrorEvent) event;
@@ -188,31 +184,12 @@ final class ScriptRunner implements Callable<ScriptPair> {
             throw new IllegalArgumentException(String.format(
                     "Barrier with %s is not present in the script and thus can't be waited upon", barrierName));
         }
-        final CountDownLatch notifiedLatch = new CountDownLatch(1);
-        final BarrierStateMachine barrierStateMachine = barriers.get(barrierName);
-        barrierStateMachine.addListener(new BarrierStateListener() {
-
-            @Override
-            public void initial() {
-                // NOOP
-            }
-
-            @Override
-            public void notifying() {
-                // NOOP
-            }
-
-            @Override
-            public void notified() {
-                notifiedLatch.countDown();
-            }
-
-        });
         try {
             controller.sendAwaitBarrier(barrierName);
         } catch (Exception e) {
             latch.notifyException(e);
         }
+        final CountDownLatch notifiedLatch = barriers.get(barrierName);
         notifiedLatch.await();
     }
 
@@ -221,101 +198,17 @@ final class ScriptRunner implements Callable<ScriptPair> {
             throw new IllegalArgumentException(String.format(
                     "Barrier with %s is not present in the script and thus can't be notified", barrierName));
         }
-        final CountDownLatch notifiedLatch = new CountDownLatch(1);
-        final BarrierStateMachine barrierStateMachine = barriers.get(barrierName);
-        barrierStateMachine.addListener(new BarrierStateListener() {
-
-            @Override
-            public void initial() {
-                barrierStateMachine.notifying();
-                // Only write to wire once
-                try {
-                    controller.notifyBarrier(barrierName);
-                } catch (Exception e) {
-                    latch.notifyException(e);
-                }
+        final CountDownLatch notifiedLatch = barriers.get(barrierName);
+        if (notifiedLatch.getCount() > 0) {
+            try {
+                controller.notifyBarrier(barrierName);
+            } catch (Exception e) {
+                latch.notifyException(e);
             }
-
-            @Override
-            public void notifying() {
-                // NOOP
-            }
-
-            @Override
-            public void notified() {
-                notifiedLatch.countDown();
-            }
-        });
+        }
         notifiedLatch.await();
     }
 
-    private interface BarrierStateListener {
-        void initial();
-
-        void notified();
-
-        void notifying();
-    }
-
-    enum BarrierState {
-        INITIAL, NOTIFYING, NOTIFIED;
-    }
-
-    private class BarrierStateMachine implements BarrierStateListener {
-
-        private BarrierState state = INITIAL;
-        private List<BarrierStateListener> stateListeners = new ArrayList<>();
-
-        @Override
-        public void initial() {
-            synchronized (this) {
-                this.state = NOTIFYING;
-                for (BarrierStateListener listener : stateListeners) {
-                    listener.initial();
-                }
-            }
-        }
-
-        @Override
-        public void notifying() {
-            synchronized (this) {
-                this.state = NOTIFYING;
-                for (BarrierStateListener listener : stateListeners) {
-                    listener.notifying();
-                }
-            }
-        }
-
-        @Override
-        public void notified() {
-            synchronized (this) {
-                this.state = NOTIFIED;
-                for (BarrierStateListener listener : stateListeners) {
-                    listener.notified();
-                }
-            }
-        }
-
-        public void addListener(BarrierStateListener stateListener) {
-            synchronized (this) {
-                switch (this.state) {
-                // notify right away if waiting on state
-                case INITIAL:
-                    stateListener.initial();
-                    break;
-                case NOTIFYING:
-                    stateListener.notify();
-                    break;
-                case NOTIFIED:
-                    stateListener.notified();
-                    break;
-                default:
-                    break;
-                }
-                stateListeners.add(stateListener);
-            }
-        }
-    }
 
     public void dispose() throws Exception {
         try {

--- a/junit/src/main/java/org/kaazing/k3po/junit/rules/SpecificationStatement.java
+++ b/junit/src/main/java/org/kaazing/k3po/junit/rules/SpecificationStatement.java
@@ -55,10 +55,10 @@ final class SpecificationStatement extends Statement {
             // start the script execution
             new Thread(scriptFuture).start();
 
-            // wait for script to be prepared (all binds ready for incoming connections from statement)
-            latch.awaitPrepared();
-
             try {
+                // wait for script to be prepared (all binds ready for incoming connections from statement)
+                latch.awaitPrepared();
+
                 // note: JUnit timeout will trigger an exception
                 statement.evaluate();
             } catch (AssumptionViolatedException e) {
@@ -72,6 +72,10 @@ final class SpecificationStatement extends Statement {
                 // any exception aborts the script (including timeout)
                 if (latch.hasException()) {
                     // propagate exception if the latch has an exception
+                	if (cause instanceof InterruptedException) {
+                		// take the error from the latch, it is more meaningful
+                		throw latch.getException();
+                	}
                     throw cause;
                 } else {
                     // It is possible that the script is finished even if we get an exception

--- a/junit/src/main/java/org/kaazing/k3po/junit/rules/SpecificationStatement.java
+++ b/junit/src/main/java/org/kaazing/k3po/junit/rules/SpecificationStatement.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 
@@ -58,7 +57,15 @@ final class SpecificationStatement extends Statement {
             try {
                 // wait for script to be prepared (all binds ready for incoming connections from statement)
                 latch.awaitPrepared();
+            } catch (InterruptedException e) {
+                if (latch.hasException()) {
+                    // propagate exception if the latch has an exception
+                    throw latch.getException();
+                } else
+                    throw e;
+            }
 
+            try {
                 // note: JUnit timeout will trigger an exception
                 statement.evaluate();
             } catch (AssumptionViolatedException e) {
@@ -100,9 +107,8 @@ final class SpecificationStatement extends Statement {
                             // Throw the original exception if we are equal
                             throw cause;
                         } catch (ComparisonFailure f) {
-                            // throw an exception that highlights the difference in behavior, but caused by the timeout
-                            // (or
-                            // original exception)
+                            // throw an exception that highlights the difference in behavior, but caused by the timeout 
+                            // (or original exception)
                             f.initCause(cause);
                             throw f;
                         }
@@ -116,10 +122,11 @@ final class SpecificationStatement extends Statement {
                 }
             }
 
+            // Stefan - not sure what the comment bellow is about. There is no join() method in the statement or rule class.
             // note: statement MUST call join() to ensure wrapped Rule(s) do not complete early
             // and to allow Specification script(s) to make progress
             String k3poSimpleName = K3poRule.class.getSimpleName();
-            assertTrue(format("Did you instantiate %s with a @Rule and call %s.join()?", k3poSimpleName, k3poSimpleName),
+            assertTrue(format("Did you instantiate %s with a @Rule and call %s.start() or %s.finish()?", k3poSimpleName, k3poSimpleName, k3poSimpleName),
                     latch.isStartable());
 
             ScriptPair scripts = scriptFuture.get();
@@ -137,7 +144,6 @@ final class SpecificationStatement extends Statement {
 
     public void awaitBarrier(String barrierName) throws InterruptedException {
         scriptRunner.awaitBarrier(barrierName);
-
     }
 
     public void notifyBarrier(String barrierName) throws InterruptedException {


### PR DESCRIPTION
This includes the following:
- fix for https://github.com/k3po/k3po/issues/388 (removal of wait statements)
- modification of logic according to new k3po specs
- small fix to improve exception reporting - in case an InterruptedException is caused by a driver error, the driver exception should be reported instead.
- fix for https://github.com/k3po/k3po/issues/391 (interrupted status)
- fix for https://github.com/k3po/k3po/issues/393 (rewriting of ControlDecoder)