### PR TITLE
Sporadic failure in ConnectionManagementIT

### DIFF
--- a/specification/http/src/main/scripts/org/kaazing/specification/http/rfc7230/connection.management/client.with.pipelining.must.not.retry.pipelining.immediately.after.failure/request.rpt
+++ b/specification/http/src/main/scripts/org/kaazing/specification/http/rfc7230/connection.management/client.with.pipelining.must.not.retry.pipelining.immediately.after.failure/request.rpt
@@ -29,6 +29,7 @@ read "HTTP/1.1 200 OK\r\n"
 read "Content-Length: 8\r\n"
 read "\r\n"
 read "request1"
+closed
 read notify REPLAY_REQUEST_2
 
 connect await REPLAY_REQUEST_2


### PR DESCRIPTION
Test ConnectionManagementIT#clientWithPipeliningMustNotRetryPipeliningImmediatelyAfterFailure fails in Ubuntu but is successful under Windows.