### PR TITLE
Implement aborted event

### DIFF
--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/event/AbortedHandler.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/event/AbortedHandler.java
@@ -19,9 +19,26 @@ package org.kaazing.k3po.driver.internal.behavior.handler.event;
 import static java.util.EnumSet.of;
 import static org.kaazing.k3po.driver.internal.behavior.handler.event.AbstractEventHandler.ChannelEventKind.ABORTED;
 
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.kaazing.k3po.driver.internal.netty.channel.AbortEvent;
+
 public class AbortedHandler extends AbstractEventHandler {
 
     public AbortedHandler() {
         super(of(ABORTED));
+    }
+
+    @Override
+    public void aborted(ChannelHandlerContext ctx, AbortEvent e) {
+
+        ChannelFuture handlerFuture = getHandlerFuture();
+        assert handlerFuture != null;
+        handlerFuture.setSuccess();
+    }
+
+    @Override
+    protected StringBuilder describe(StringBuilder sb) {
+        return sb.append("aborted");
     }
 }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/event/AbstractEventHandler.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/event/AbstractEventHandler.java
@@ -19,6 +19,7 @@ import static java.lang.Boolean.TRUE;
 import static java.lang.String.format;
 import static java.util.EnumSet.complementOf;
 import static java.util.EnumSet.of;
+import static org.kaazing.k3po.driver.internal.behavior.handler.event.AbstractEventHandler.ChannelEventKind.ABORTED;
 import static org.kaazing.k3po.driver.internal.behavior.handler.event.AbstractEventHandler.ChannelEventKind.BOUND;
 import static org.kaazing.k3po.driver.internal.behavior.handler.event.AbstractEventHandler.ChannelEventKind.CHILD_CLOSED;
 import static org.kaazing.k3po.driver.internal.behavior.handler.event.AbstractEventHandler.ChannelEventKind.CHILD_OPEN;
@@ -53,6 +54,7 @@ import org.jboss.netty.channel.WriteCompletionEvent;
 import org.jboss.netty.handler.timeout.IdleStateEvent;
 import org.kaazing.k3po.driver.internal.behavior.ScriptProgressException;
 import org.kaazing.k3po.driver.internal.behavior.handler.ExecutionHandler;
+import org.kaazing.k3po.driver.internal.netty.channel.AbortEvent;
 import org.kaazing.k3po.driver.internal.netty.channel.FlushEvent;
 import org.kaazing.k3po.driver.internal.netty.channel.ShutdownInputEvent;
 import org.kaazing.k3po.driver.internal.netty.channel.ShutdownOutputEvent;
@@ -121,6 +123,8 @@ public abstract class AbstractEventHandler extends ExecutionHandler {
                 throw new ScriptProgressException(getRegionInfo(), "closed");
             case FLUSHED:
                 throw new ScriptProgressException(getRegionInfo(), "flushed");
+            case ABORTED:
+                throw new ScriptProgressException(getRegionInfo(), "aborted");
             case MESSAGE:
                 throw new ScriptProgressException(getRegionInfo(), "read ...");
             case INPUT_SHUTDOWN:
@@ -150,6 +154,10 @@ public abstract class AbstractEventHandler extends ExecutionHandler {
     }
 
     private static ChannelEventKind asEventKind(ChannelEvent evt) {
+        if (evt instanceof AbortEvent) {
+            return ABORTED;
+        }
+
         if (evt instanceof ShutdownInputEvent) {
             return INPUT_SHUTDOWN;
         }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/http/HttpChildChannel.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/http/HttpChildChannel.java
@@ -15,8 +15,6 @@
  */
 package org.kaazing.k3po.driver.internal.netty.bootstrap.http;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.jboss.netty.channel.ChannelFactory;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.ChannelSink;
@@ -27,15 +25,13 @@ import org.kaazing.k3po.driver.internal.netty.channel.ChannelAddress;
 public final class HttpChildChannel extends AbstractChannel<HttpChannelConfig> {
 
     public enum HttpReadState { REQUEST, CONTENT_CHUNKED, CONTENT_COMPLETE, UPGRADED }
-    public enum HttpWriteState { RESPONSE, CONTENT_CHUNKED, CONTENT_CLOSE, CONTENT_BUFFERED, CONTENT_COMPLETE, UPGRADED }
+    public enum HttpWriteState { RESPONSE, CONTENT_CHUNKED, CONTENT_CLOSE, CONTENT_CLOSING, CONTENT_BUFFERED, CONTENT_COMPLETE, UPGRADED }
 
-    private final AtomicInteger closeState;
     private HttpReadState readState;
     private HttpWriteState writeState;
 
     HttpChildChannel(ServerChannel parent, ChannelFactory factory, ChannelPipeline pipeline, ChannelSink sink) {
         super(parent, factory, pipeline, sink, new DefaultHttpChannelConfig());
-        this.closeState = new AtomicInteger();
         this.readState = HttpReadState.REQUEST;
         this.writeState = HttpWriteState.RESPONSE;
     }
@@ -77,22 +73,14 @@ public final class HttpChildChannel extends AbstractChannel<HttpChannelConfig> {
     }
 
     protected boolean setReadClosed() {
-        if ((this.closeState.get() & 0x01) == 0x00) {
-            int closeStatus = this.closeState.addAndGet(1);
-            if (closeStatus == 0x03) {
-                return super.setClosed();
-            }
-        }
-        return false;
+        return super.setReadClosed();
     }
 
     protected boolean setWriteClosed() {
-        if ((this.closeState.get() & 0x02) == 0x00) {
-            int closeStatus = this.closeState.addAndGet(2);
-            if (closeStatus == 0x03) {
-                return super.setClosed();
-            }
-        }
-        return false;
+        return super.setWriteClosed();
+    }
+
+    protected boolean setAborted() {
+        return super.setAborted();
     }
 }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/http/HttpClientChannelSink.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/http/HttpClientChannelSink.java
@@ -266,9 +266,6 @@ public class HttpClientChannelSink extends AbstractChannelSink {
     @Override
     protected void abortRequested(ChannelPipeline pipeline, final AbortEvent evt) throws Exception {
         HttpClientChannel channel = (HttpClientChannel) pipeline.getChannel();
-        // We flush before an abort, as we don't expect script authors
-        // to purposely add a write before an abort and not expect it
-        // to make it on the wire
         ChannelFuture flushFuture = Channels.future(channel);
         flushRequested(channel, flushFuture);
         flushFuture.addListener(new ChannelFutureListener() {

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/http/HttpClientChannelSource.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/http/HttpClientChannelSource.java
@@ -23,11 +23,11 @@ import static org.jboss.netty.channel.Channels.fireChannelUnbound;
 import static org.jboss.netty.channel.Channels.fireExceptionCaught;
 import static org.jboss.netty.channel.Channels.fireMessageReceived;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.SWITCHING_PROTOCOLS;
+import static org.kaazing.k3po.driver.internal.netty.channel.Channels.fireChannelAborted;
 import static org.kaazing.k3po.driver.internal.netty.channel.Channels.fireInputShutdown;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
-import org.jboss.netty.channel.ChannelException;
 import org.jboss.netty.channel.ChannelHandler;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelPipeline;
@@ -158,7 +158,12 @@ public class HttpClientChannelSource extends HttpChannelHandler {
 
     @Override
     public void channelClosed(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception {
+
+        HttpClientChannel httpClientChannel = this.httpClientChannel;
         if (httpClientChannel != null) {
+
+            this.httpClientChannel = null;
+
             HttpChannelConfig httpClientConfig = httpClientChannel.getConfig();
             HttpResponseStatus httpStatus = httpClientConfig.getStatus();
             int httpStatusCode = (httpStatus != null) ? httpStatus.getCode() : 0;
@@ -170,9 +175,7 @@ public class HttpClientChannelSource extends HttpChannelHandler {
                 }
             }
             else {
-                ChannelException exception = new ChannelException("transport closed unexpectedly");
-                exception.fillInStackTrace();
-                fireExceptionCaught(httpClientChannel, exception);
+                fireChannelAborted(httpClientChannel);
             }
         }
     }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/ClientBootstrapResolver.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/resolver/ClientBootstrapResolver.java
@@ -68,6 +68,7 @@ public class ClientBootstrapResolver {
             LOGGER.debug("Initializing client Bootstrap connecting to remoteAddress " + remoteAddress);
             ClientBootstrap clientBootstrapCandidate = bootstrapFactory.newClientBootstrap(connectURI.getScheme());
             clientBootstrapCandidate.setPipelineFactory(pipelineFactory);
+            clientBootstrapCandidate.setOptions(connectOptions);
             clientBootstrapCandidate.setOption("remoteAddress", remoteAddress);
             bootstrap = clientBootstrapCandidate;
         }

--- a/driver/src/test/resources/org/kaazing/k3po/driver/internal/http/http.server.channel.aborted/response.rpt
+++ b/driver/src/test/resources/org/kaazing/k3po/driver/internal/http/http.server.channel.aborted/response.rpt
@@ -19,4 +19,5 @@ accepted
 connected
 
 read http:method "GET"
+read closed
 aborted

--- a/lang/src/main/java/org/kaazing/k3po/lang/internal/parser/ScriptParseStrategy.java
+++ b/lang/src/main/java/org/kaazing/k3po/lang/internal/parser/ScriptParseStrategy.java
@@ -1120,6 +1120,18 @@ public abstract class ScriptParseStrategy<T extends AstRegion> {
 
             return unboundNode;
         }
+
+        @Override
+        public AstAbortedNode visitAbortedNode(AbortedNodeContext ctx) {
+
+            AstAbortedNodeVisitor visitor = new AstAbortedNodeVisitor(factory, environment);
+            AstAbortedNode abortedNode = visitor.visitAbortedNode(ctx);
+            if (abortedNode != null) {
+                childInfos().add(abortedNode.getRegionInfo());
+            }
+
+            return abortedNode;
+        }
     }
 
     private static class AstCommandNodeVisitor extends AstNodeVisitor<AstCommandNode> {

--- a/specification/wse/src/test/java/org/kaazing/specification/wse/ClosingIT.java
+++ b/specification/wse/src/test/java/org/kaazing/specification/wse/ClosingIT.java
@@ -18,7 +18,6 @@ package org.kaazing.specification.wse;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;


### PR DESCRIPTION
The `aborted` keyword was being ignored during parse, now fixed.