### PR TITLE
Matchers need to be in list otherwise they are getting overwritten.

### DIFF
--- a/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/AstReadConfigNode.java
+++ b/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/AstReadConfigNode.java
@@ -17,7 +17,7 @@ package org.kaazing.k3po.lang.internal.ast;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
 
@@ -33,7 +33,7 @@ public class AstReadConfigNode extends AstEventNode {
 
     public AstReadConfigNode() {
         this.matchersByName = new LinkedHashMap<>();
-        this.matchers = new LinkedHashSet<>();
+        this.matchers = new LinkedList<>();
     }
 
     public void setType(StructuredTypeInfo type) {

--- a/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/AstWriteConfigNode.java
+++ b/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/AstWriteConfigNode.java
@@ -19,7 +19,7 @@ import static org.kaazing.k3po.lang.internal.ast.util.AstUtil.equivalent;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.Map;
 
 import org.kaazing.k3po.lang.internal.ast.value.AstValue;
@@ -32,8 +32,8 @@ public class AstWriteConfigNode extends AstCommandNode {
     private Map<String, AstValue<?>> valuesByName;
 
     public AstWriteConfigNode() {
-        this.values = new LinkedHashSet<>();
         this.valuesByName = new LinkedHashMap<>();
+        this.values = new LinkedList<>();
     }
 
     public void setType(StructuredTypeInfo type) {


### PR DESCRIPTION
For e.g:
```
read nukleus:begin.ext [0x00] [0x07] ":method" [0x04] "POST"
                       [0x00] [0x07] ":scheme" [0x04] "http"
```
The matchers for initial part of the second line are overwritten.