### PR TITLE
Support hex literal longs and integers

### DIFF
--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/MessageDecoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/MessageDecoder.java
@@ -52,7 +52,7 @@ public abstract class MessageDecoder {
         try {
             // If we don't have a cumulation buffer yet, create it
             if (cumulation == null) {
-                cumulation = ChannelBuffers.dynamicBuffer();
+                cumulation = ChannelBuffers.dynamicBuffer(buffer.order(), 256);
             }
 
             // Write the input bytes in the cumulation buffer

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/MessageEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/MessageEncoder.java
@@ -15,11 +15,13 @@
  */
 package org.kaazing.k3po.driver.internal.behavior.handler.codec;
 
+import java.nio.ByteOrder;
+
 import org.jboss.netty.buffer.ChannelBuffer;
 
 
 public interface MessageEncoder {
 
-    ChannelBuffer encode();
+    ChannelBuffer encode(ByteOrder endian);
 
 }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/ReadNumberDecoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/ReadNumberDecoder.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.k3po.driver.internal.behavior.handler.codec;
+
+import static org.kaazing.k3po.lang.internal.RegionInfo.newSequential;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.kaazing.k3po.driver.internal.behavior.ScriptProgressException;
+import org.kaazing.k3po.lang.internal.RegionInfo;
+
+public class ReadNumberDecoder extends MessageDecoder {
+
+    private final Number expected;
+
+    public ReadNumberDecoder(RegionInfo regionInfo, Number expected) {
+        super(regionInfo);
+        this.expected = expected;
+    }
+
+    @Override
+    protected Object decodeBuffer(ChannelBuffer buffer) throws Exception {
+
+        if (expected instanceof Integer)
+        {
+            return decodeBufferAsInteger(buffer);
+        }
+        else if (expected instanceof Long)
+        {
+            return decodeBufferAsLong(buffer);
+        }
+
+        throw new ScriptProgressException(getRegionInfo(), String.format("Unsupported type: %s", expected.getClass().getName()));
+    }
+
+    private Object decodeBufferAsInteger(ChannelBuffer buffer) throws Exception {
+
+        if (buffer.readableBytes() < Integer.BYTES) {
+            return null;
+        }
+
+        int observed = buffer.readInt();
+        if (observed != expected.intValue()) {
+            throw new ScriptProgressException(getRegionInfo(), Integer.toString(observed));
+        }
+
+        return buffer;
+    }
+
+    private Object decodeBufferAsLong(ChannelBuffer buffer) throws Exception {
+
+        if (buffer.readableBytes() < Long.BYTES) {
+            return null;
+        }
+
+        long observed = buffer.readLong();
+        if (observed != expected.longValue()) {
+            throw new ScriptProgressException(getRegionInfo(), Long.toString(observed));
+        }
+
+        return buffer;
+    }
+
+    @Override
+    public String toString() {
+        return expected.toString();
+    }
+
+    // unit tests
+    ReadNumberDecoder(Number expected) {
+        this(newSequential(0, 0), expected);
+    }
+}

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/WriteBytesEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/WriteBytesEncoder.java
@@ -17,6 +17,8 @@ package org.kaazing.k3po.driver.internal.behavior.handler.codec;
 
 import static org.jboss.netty.buffer.ChannelBuffers.wrappedBuffer;
 
+import java.nio.ByteOrder;
+
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.kaazing.k3po.driver.internal.util.Utils;
 
@@ -29,7 +31,7 @@ public class WriteBytesEncoder implements MessageEncoder {
     }
 
     @Override
-    public ChannelBuffer encode() {
+    public ChannelBuffer encode(ByteOrder endian) {
         return wrappedBuffer(bytes);
     }
 

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/WriteExpressionEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/WriteExpressionEncoder.java
@@ -18,6 +18,7 @@ package org.kaazing.k3po.driver.internal.behavior.handler.codec;
 import static org.jboss.netty.buffer.ChannelBuffers.buffer;
 import static org.jboss.netty.buffer.ChannelBuffers.wrappedBuffer;
 
+import java.nio.ByteOrder;
 import java.util.function.Supplier;
 
 import javax.el.ValueExpression;
@@ -39,7 +40,7 @@ public class WriteExpressionEncoder implements MessageEncoder {
     }
 
     @Override
-    public ChannelBuffer encode() {
+    public ChannelBuffer encode(ByteOrder endian) {
 
         final byte[] value = supplier.get();
         final ChannelBuffer result;

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/WriteIntegerEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/WriteIntegerEncoder.java
@@ -25,15 +25,13 @@ import org.jboss.netty.buffer.ChannelBuffer;
 public class WriteIntegerEncoder implements MessageEncoder {
 
     private final int value;
-    private final ByteOrder endian;
 
-    public WriteIntegerEncoder(int value, ByteOrder endian) {
+    public WriteIntegerEncoder(int value) {
         this.value = value;
-        this.endian = endian;
     }
 
     @Override
-    public ChannelBuffer encode() {
+    public ChannelBuffer encode(ByteOrder endian) {
         byte[] array = ByteBuffer.allocate(Integer.BYTES)
                                  .order(endian)
                                  .putInt(value)

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/WriteLongEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/WriteLongEncoder.java
@@ -25,15 +25,13 @@ import org.jboss.netty.buffer.ChannelBuffer;
 public class WriteLongEncoder implements MessageEncoder {
 
     private final long value;
-    private final ByteOrder endian;
 
-    public WriteLongEncoder(long value, ByteOrder endian) {
+    public WriteLongEncoder(long value) {
         this.value = value;
-        this.endian = endian;
     }
 
     @Override
-    public ChannelBuffer encode() {
+    public ChannelBuffer encode(ByteOrder endian) {
         byte[] array = ByteBuffer.allocate(Long.BYTES)
                                  .order(endian)
                                  .putLong(value)

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/WriteTextEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/WriteTextEncoder.java
@@ -17,6 +17,7 @@ package org.kaazing.k3po.driver.internal.behavior.handler.codec;
 
 import static org.jboss.netty.buffer.ChannelBuffers.copiedBuffer;
 
+import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 
 import org.jboss.netty.buffer.ChannelBuffer;
@@ -32,7 +33,7 @@ public class WriteTextEncoder implements MessageEncoder {
     }
 
     @Override
-    public ChannelBuffer encode() {
+    public ChannelBuffer encode(ByteOrder endian) {
         return copiedBuffer(text, charset);
     }
 

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpHeaderEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpHeaderEncoder.java
@@ -18,6 +18,7 @@ package org.kaazing.k3po.driver.internal.behavior.handler.codec.http;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
+import java.nio.ByteOrder;
 import java.util.List;
 
 import org.jboss.netty.channel.Channel;
@@ -40,16 +41,17 @@ public class HttpHeaderEncoder implements ConfigEncoder {
     public void encode(Channel channel) throws Exception {
         HttpChannelConfig httpConfig = (HttpChannelConfig) channel.getConfig();
         HttpHeaders writeHeaders = httpConfig.getWriteHeaders();
+        ByteOrder endian = httpConfig.getEndian();
 
-        String headerName = nameEncoder.encode().toString(US_ASCII);
+        String headerName = nameEncoder.encode(endian).toString(US_ASCII);
         if (valueEncoders.size() == 1) {
             MessageEncoder valueEncoder = valueEncoders.get(0);
-            String headerValue = valueEncoder.encode().toString(US_ASCII);
+            String headerValue = valueEncoder.encode(endian).toString(US_ASCII);
             writeHeaders.add(headerName, headerValue);
         }
         else {
             for (MessageEncoder valueEncoder : valueEncoders) {
-                String headerValue = valueEncoder.encode().toString(US_ASCII);
+                String headerValue = valueEncoder.encode(endian).toString(US_ASCII);
                 writeHeaders.add(headerName, headerValue);
             }
         }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpMethodEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpMethodEncoder.java
@@ -18,6 +18,8 @@ package org.kaazing.k3po.driver.internal.behavior.handler.codec.http;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
+import java.nio.ByteOrder;
+
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.kaazing.k3po.driver.internal.behavior.handler.codec.ConfigEncoder;
@@ -35,7 +37,8 @@ public class HttpMethodEncoder implements ConfigEncoder {
     @Override
     public void encode(Channel channel) throws Exception {
         HttpChannelConfig httpConfig = (HttpChannelConfig) channel.getConfig();
-        String methodName = methodEncoder.encode().toString(US_ASCII);
+        ByteOrder endian = httpConfig.getEndian();
+        String methodName = methodEncoder.encode(endian).toString(US_ASCII);
         HttpMethod method = HttpMethod.valueOf(methodName);
         httpConfig.setMethod(method);
     }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpParameterEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpParameterEncoder.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.kaazing.k3po.driver.internal.channel.Channels.remoteAddress;
 
 import java.net.URI;
+import java.nio.ByteOrder;
 import java.util.List;
 
 import org.jboss.netty.channel.Channel;
@@ -49,9 +50,10 @@ public class HttpParameterEncoder implements ConfigEncoder {
             httpConfig.setWriteQuery(query);
         }
 
-        String paramName = nameEncoder.encode().toString(US_ASCII);
+        ByteOrder endian = httpConfig.getEndian();
+        String paramName = nameEncoder.encode(endian).toString(US_ASCII);
         for (MessageEncoder valueEncoder : valueEncoders) {
-            String paramValue = valueEncoder.encode().toString(US_ASCII);
+            String paramValue = valueEncoder.encode(endian).toString(US_ASCII);
             query.addParam(paramName, paramValue);
         }
     }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpRequestFormEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpRequestFormEncoder.java
@@ -18,6 +18,8 @@ package org.kaazing.k3po.driver.internal.behavior.handler.codec.http;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
+import java.nio.ByteOrder;
+
 import org.jboss.netty.channel.Channel;
 import org.kaazing.k3po.driver.internal.behavior.handler.codec.ConfigEncoder;
 import org.kaazing.k3po.driver.internal.behavior.handler.codec.MessageEncoder;
@@ -35,7 +37,8 @@ public class HttpRequestFormEncoder implements ConfigEncoder {
     @Override
     public void encode(Channel channel) throws Exception {
         HttpChannelConfig httpConfig = (HttpChannelConfig) channel.getConfig();
-        String formName = formEncoder.encode().toString(US_ASCII);
+        ByteOrder endian = httpConfig.getEndian();
+        String formName = formEncoder.encode(endian).toString(US_ASCII);
         HttpRequestForm form = HttpRequestForm.valueOf(formName);
         httpConfig.setRequestForm(form);
     }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpStatusEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpStatusEncoder.java
@@ -18,6 +18,8 @@ package org.kaazing.k3po.driver.internal.behavior.handler.codec.http;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
+import java.nio.ByteOrder;
+
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.kaazing.k3po.driver.internal.behavior.handler.codec.ConfigEncoder;
@@ -37,8 +39,9 @@ public class HttpStatusEncoder implements ConfigEncoder {
     @Override
     public void encode(Channel channel) throws Exception {
         HttpChannelConfig httpConfig = (HttpChannelConfig) channel.getConfig();
-        int code = Integer.parseInt(codeEncoder.encode().toString(US_ASCII));
-        String reason = reasonEncoder.encode().toString(US_ASCII);
+        ByteOrder endian = httpConfig.getEndian();
+        int code = Integer.parseInt(codeEncoder.encode(endian).toString(US_ASCII));
+        String reason = reasonEncoder.encode(endian).toString(US_ASCII);
         HttpResponseStatus status = new HttpResponseStatus(code, reason);
         httpConfig.setStatus(status);
     }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpTrailerEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpTrailerEncoder.java
@@ -18,6 +18,7 @@ package org.kaazing.k3po.driver.internal.behavior.handler.codec.http;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
+import java.nio.ByteOrder;
 import java.util.List;
 
 import org.jboss.netty.channel.Channel;
@@ -39,17 +40,17 @@ public class HttpTrailerEncoder implements ConfigEncoder {
     @Override
     public void encode(Channel channel) throws Exception {
         HttpChannelConfig httpConfig = (HttpChannelConfig) channel.getConfig();
-
         HttpHeaders writeTrailers = httpConfig.getWriteTrailers();
+        ByteOrder endian = httpConfig.getEndian();
 
-        String headerName = nameEncoder.encode().toString(US_ASCII);
+        String headerName = nameEncoder.encode(endian).toString(US_ASCII);
         if (valueEncoders.size() == 1) {
             MessageEncoder valueEncoder = valueEncoders.get(0);
-            String headerValue = valueEncoder.encode().toString(US_ASCII);
+            String headerValue = valueEncoder.encode(endian).toString(US_ASCII);
             writeTrailers.add(headerName, headerValue);
         } else {
             for (MessageEncoder valueEncoder : valueEncoders) {
-                String headerValue = valueEncoder.encode().toString(US_ASCII);
+                String headerValue = valueEncoder.encode(endian).toString(US_ASCII);
                 writeTrailers.add(headerName, headerValue);
             }
         }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpVersionEncoder.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/codec/http/HttpVersionEncoder.java
@@ -18,6 +18,8 @@ package org.kaazing.k3po.driver.internal.behavior.handler.codec.http;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
+import java.nio.ByteOrder;
+
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.kaazing.k3po.driver.internal.behavior.handler.codec.ConfigEncoder;
@@ -35,7 +37,8 @@ public class HttpVersionEncoder implements ConfigEncoder {
     @Override
     public void encode(Channel channel) throws Exception {
         HttpChannelConfig httpConfig = (HttpChannelConfig) channel.getConfig();
-        String versionName = versionEncoder.encode().toString(US_ASCII);
+        ByteOrder endian = httpConfig.getEndian();
+        String versionName = versionEncoder.encode(endian).toString(US_ASCII);
         HttpVersion version = HttpVersion.valueOf(versionName);
         httpConfig.setVersion(version);
     }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/command/WriteHandler.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/behavior/handler/command/WriteHandler.java
@@ -20,12 +20,15 @@ import static org.jboss.netty.buffer.ChannelBuffers.wrappedBuffer;
 import static org.jboss.netty.channel.Channels.write;
 import static org.kaazing.k3po.driver.internal.behavior.handler.codec.Masker.IDENTITY_MASKER;
 
+import java.nio.ByteOrder;
 import java.util.List;
 
 import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.ChannelConfig;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.kaazing.k3po.driver.internal.behavior.handler.codec.Masker;
 import org.kaazing.k3po.driver.internal.behavior.handler.codec.MessageEncoder;
+import org.kaazing.k3po.driver.internal.netty.bootstrap.channel.DefaultChannelConfig;
 
 public class WriteHandler extends AbstractCommandHandler {
 
@@ -44,10 +47,12 @@ public class WriteHandler extends AbstractCommandHandler {
 
     @Override
     protected void invokeCommand(ChannelHandlerContext ctx) throws Exception {
+        ChannelConfig config = ctx.getChannel().getConfig();
+        ByteOrder endian = DefaultChannelConfig.getEndian(config);
         ChannelBuffer[] buffers = new ChannelBuffer[encoders.size()];
         int idx = 0;
         for (MessageEncoder encoder : encoders) {
-            buffers[idx] = encoder.encode();
+            buffers[idx] = encoder.encode(endian);
             idx++;
         }
 

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/agrona/AgronaChannel.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/agrona/AgronaChannel.java
@@ -17,6 +17,9 @@ package org.kaazing.k3po.driver.internal.netty.bootstrap.agrona;
 
 import static org.jboss.netty.buffer.ChannelBuffers.dynamicBuffer;
 import static org.jboss.netty.channel.Channels.fireMessageReceived;
+
+import java.nio.ByteOrder;
+
 import static org.agrona.BitUtil.SIZE_OF_INT;
 
 import org.jboss.netty.buffer.ChannelBuffer;
@@ -33,13 +36,15 @@ import org.agrona.concurrent.MessageHandler;
 
 public abstract class AgronaChannel extends AbstractChannel<AgronaChannelConfig> {
 
+    private static final ByteOrder NATIVE_ORDER = ByteOrder.nativeOrder();
+
     final AgronaWorker worker;
 
     final MessageHandler messageHandler = new MessageHandler() {
 
         @Override
         public void onMessage(int msgTypeId, MutableDirectBuffer buffer, int index, int length) {
-            ChannelBuffer message = ChannelBuffers.buffer(SIZE_OF_INT + length);
+            ChannelBuffer message = ChannelBuffers.buffer(NATIVE_ORDER, SIZE_OF_INT + length);
             message.setInt(0, msgTypeId);
             buffer.getBytes(index, message.array(), message.arrayOffset() + SIZE_OF_INT, length);
             message.writerIndex(SIZE_OF_INT + length);

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/agrona/AgronaChannel.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/agrona/AgronaChannel.java
@@ -53,7 +53,7 @@ public abstract class AgronaChannel extends AbstractChannel<AgronaChannelConfig>
 
     };
 
-    final ChannelBuffer writeBuffer = dynamicBuffer(8192);
+    final ChannelBuffer writeBuffer = dynamicBuffer(NATIVE_ORDER, 8192);
 
     AgronaChannel(AgronaServerChannel parent, ChannelFactory factory,
             ChannelPipeline pipeline, ChannelSink sink, AgronaWorker worker) {

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/agrona/DefaultAgronaChannelConfig.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/agrona/DefaultAgronaChannelConfig.java
@@ -15,9 +15,14 @@
  */
 package org.kaazing.k3po.driver.internal.netty.bootstrap.agrona;
 
-import org.jboss.netty.channel.DefaultChannelConfig;
+import java.nio.ByteOrder;
+
+import org.kaazing.k3po.driver.internal.netty.bootstrap.channel.DefaultChannelConfig;
 
 public class DefaultAgronaChannelConfig extends DefaultChannelConfig implements AgronaChannelConfig {
 
-
+    public DefaultAgronaChannelConfig() {
+        super();
+        setEndian(ByteOrder.nativeOrder());
+    }
 }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/agrona/DefaultAgronaServerChannelConfig.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/agrona/DefaultAgronaServerChannelConfig.java
@@ -15,9 +15,14 @@
  */
 package org.kaazing.k3po.driver.internal.netty.bootstrap.agrona;
 
-import org.jboss.netty.channel.DefaultServerChannelConfig;
+import java.nio.ByteOrder;
+
+import org.kaazing.k3po.driver.internal.netty.bootstrap.channel.DefaultServerChannelConfig;
 
 public class DefaultAgronaServerChannelConfig extends DefaultServerChannelConfig implements AgronaChannelConfig {
 
-
+    public DefaultAgronaServerChannelConfig() {
+        super();
+        setEndian(ByteOrder.nativeOrder());
+    }
 }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/channel/ChannelConfig.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/channel/ChannelConfig.java
@@ -15,11 +15,12 @@
  */
 package org.kaazing.k3po.driver.internal.netty.bootstrap.channel;
 
+import java.nio.ByteOrder;
 import java.util.Map;
 
 public interface ChannelConfig extends org.jboss.netty.channel.ChannelConfig
 {
+    ByteOrder getEndian();
 
     Map<String, Object> getTransportOptions();
-
 }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/channel/DefaultChannelConfig.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/channel/DefaultChannelConfig.java
@@ -15,6 +15,7 @@
  */
 package org.kaazing.k3po.driver.internal.netty.bootstrap.channel;
 
+import java.nio.ByteOrder;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,7 +23,33 @@ import java.util.Map;
 public class DefaultChannelConfig extends org.jboss.netty.channel.DefaultChannelConfig
     implements ChannelConfig
 {
+    private static final ByteOrder DEFAULT_ENDIAN = ByteOrder.BIG_ENDIAN;
+
+    private ByteOrder endian = DEFAULT_ENDIAN;
     private final Map<String, Object> transportOptions = new HashMap<>();
+
+    public static ByteOrder getEndian(org.jboss.netty.channel.ChannelConfig config) {
+
+        ByteOrder endian = DEFAULT_ENDIAN;
+
+        if (config instanceof ChannelConfig) {
+            endian = ((ChannelConfig) config).getEndian();
+        }
+
+        return endian;
+    }
+
+    @Override
+    public ByteOrder getEndian()
+    {
+        return endian;
+    }
+
+    public void setEndian(
+        ByteOrder endian)
+    {
+        this.endian = endian;
+    }
 
     @Override
     public final boolean setOption(String key, Object value)

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/channel/DefaultServerChannelConfig.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/netty/bootstrap/channel/DefaultServerChannelConfig.java
@@ -15,6 +15,7 @@
  */
 package org.kaazing.k3po.driver.internal.netty.bootstrap.channel;
 
+import java.nio.ByteOrder;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,7 +23,20 @@ import java.util.Map;
 public class DefaultServerChannelConfig extends org.jboss.netty.channel.DefaultServerChannelConfig
     implements ChannelConfig
 {
+    private ByteOrder endian = ByteOrder.BIG_ENDIAN;
     private final Map<String, Object> transportOptions = new HashMap<>();
+
+    @Override
+    public ByteOrder getEndian()
+    {
+        return endian;
+    }
+
+    public void setEndian(
+        ByteOrder endian)
+    {
+        this.endian = endian;
+    }
 
     @Override
     public final boolean setOption(String key, Object value)

--- a/driver/src/test/java/org/kaazing/k3po/driver/internal/RobotIT.java
+++ b/driver/src/test/java/org/kaazing/k3po/driver/internal/RobotIT.java
@@ -844,38 +844,6 @@ public class RobotIT {
     }
 
     @Test
-    public void shouldReadByteLiteralOK() throws Exception {
-        // @formatter:off
-        String script =
-            "connect 'tcp://localhost:8080'\n" +
-            "connected\n" +
-            "read 0xFF\n" +
-            "close\n" +
-            "closed\n";
-
-        String expected = script;
-        // @formatter:on
-
-        server.bind(new InetSocketAddress("localhost", 8080));
-
-        robot.prepareAndStart(script).await();
-
-        accepted = server.accept();
-
-        byte[] b = new byte[]{(byte) 0xff};
-
-        OutputStream out = accepted.getOutputStream();
-        out.write(b);
-        out.flush();
-
-        robot.finish().await();
-
-        assertEquals(expected, robot.getObservedScript());
-
-        assertEquals(-1, accepted.getInputStream().read());
-    }
-
-    @Test
     public void shouldReadCaptureByteOK() throws Exception {
         // @formatter:off
         String script =
@@ -951,38 +919,6 @@ public class RobotIT {
             "connect 'tcp://localhost:8080'\n" +
             "connected\n" +
             "read [0..2]\n" +
-            "close\n" +
-            "closed\n";
-
-        String expected = script;
-        // @formatter:on
-
-        server.bind(new InetSocketAddress("localhost", 8080));
-
-        robot.prepareAndStart(script).await();
-
-        accepted = server.accept();
-
-        byte[] b = new byte[]{0x00, 0x01};
-
-        OutputStream out = accepted.getOutputStream();
-        out.write(b);
-        out.flush();
-
-        robot.finish().await();
-
-        assertEquals(expected, robot.getObservedScript());
-
-        assertEquals(-1, accepted.getInputStream().read());
-    }
-
-    @Test
-    public void shouldReadShortLiteralOK() throws Exception {
-        // @formatter:off
-        String script =
-            "connect 'tcp://localhost:8080'\n" +
-            "connected\n" +
-            "read 0x0001\n" +
             "close\n" +
             "closed\n";
 

--- a/driver/src/test/java/org/kaazing/k3po/driver/internal/agrona/Functions.java
+++ b/driver/src/test/java/org/kaazing/k3po/driver/internal/agrona/Functions.java
@@ -45,6 +45,16 @@ public final class Functions {
     }
 
     @Function
+    public static Integer randomInt() {
+        return RANDOM.nextInt();
+    }
+
+    @Function
+    public static Long randomLong() {
+        return RANDOM.nextLong();
+    }
+
+    @Function
     public static Layout layoutInit(String filename, int ringCapacity, int broadcastCapacity) {
         return layout(filename, ringCapacity, broadcastCapacity, true);
     }

--- a/driver/src/test/java/org/kaazing/k3po/driver/internal/netty/bootstrap/agrona/AgronaClientBootstrapTest.java
+++ b/driver/src/test/java/org/kaazing/k3po/driver/internal/netty/bootstrap/agrona/AgronaClientBootstrapTest.java
@@ -17,6 +17,7 @@ package org.kaazing.k3po.driver.internal.netty.bootstrap.agrona;
 
 import static java.lang.String.format;
 import static java.lang.Thread.sleep;
+import static java.nio.ByteOrder.nativeOrder;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jboss.netty.buffer.ChannelBuffers.buffer;
@@ -42,6 +43,15 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.MessageHandler;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.broadcast.BroadcastBufferDescriptor;
+import org.agrona.concurrent.broadcast.BroadcastReceiver;
+import org.agrona.concurrent.broadcast.BroadcastTransmitter;
+import org.agrona.concurrent.broadcast.CopyBroadcastReceiver;
+import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
+import org.agrona.concurrent.ringbuffer.RingBufferDescriptor;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelEvent;
@@ -69,16 +79,6 @@ import org.kaazing.k3po.driver.internal.netty.channel.agrona.CopyBroadcastReceiv
 import org.kaazing.k3po.driver.internal.netty.channel.agrona.RingBufferChannelReader;
 import org.kaazing.k3po.driver.internal.netty.channel.agrona.RingBufferChannelWriter;
 import org.mockito.InOrder;
-
-import org.agrona.MutableDirectBuffer;
-import org.agrona.concurrent.MessageHandler;
-import org.agrona.concurrent.UnsafeBuffer;
-import org.agrona.concurrent.broadcast.BroadcastBufferDescriptor;
-import org.agrona.concurrent.broadcast.BroadcastReceiver;
-import org.agrona.concurrent.broadcast.BroadcastTransmitter;
-import org.agrona.concurrent.broadcast.CopyBroadcastReceiver;
-import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
-import org.agrona.concurrent.ringbuffer.RingBufferDescriptor;
 
 @RunWith(Theories.class)
 public class AgronaClientBootstrapTest {
@@ -168,7 +168,7 @@ public class AgronaClientBootstrapTest {
         options.put(OPTION_WRITER, pingWriter);
         ChannelAddress channelAddress = channelAddressFactory.newChannelAddress(location, options);
 
-        ChannelBuffer ping = buffer(256);
+        ChannelBuffer ping = buffer(nativeOrder(), 256);
         ping.writeInt(0x01);
         ping.writeBytes("Hello, world".getBytes(UTF_8));
 

--- a/driver/src/test/java/org/kaazing/k3po/driver/internal/test/utils/ThreadCountTestRule.java
+++ b/driver/src/test/java/org/kaazing/k3po/driver/internal/test/utils/ThreadCountTestRule.java
@@ -15,7 +15,8 @@
  */
 package org.kaazing.k3po.driver.internal.test.utils;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
 
 import java.util.Iterator;
 import java.util.Set;
@@ -72,8 +73,8 @@ public class ThreadCountTestRule implements TestRule {
                         System.out.println(type.getName());
                     }
                 }
-                
-                assertEquals("Number of threads is not equal", threadCountBefore, threadCountAfter);
+
+                assertThat(threadCountAfter, lessThanOrEqualTo(threadCountBefore));
             }
         };
     }

--- a/driver/src/test/resources/org/kaazing/k3po/driver/internal/agrona/client.rpt
+++ b/driver/src/test/resources/org/kaazing/k3po/driver/internal/agrona/client.rpt
@@ -25,13 +25,13 @@ connect "agrona://stream/bidirectional"
 
 connected
 
-write [0x00 0x00 0x00 0x01]
+write 0x00000001
 write ${client32}
 write ${clientInt}
 write ${clientLong}
 write flush
 
-read [0x00 0x00 0x00 0x02]
+read 0x00000002
 read ${client32}
 read ${clientInt}
 read ${clientLong}

--- a/driver/src/test/resources/org/kaazing/k3po/driver/internal/agrona/client.rpt
+++ b/driver/src/test/resources/org/kaazing/k3po/driver/internal/agrona/client.rpt
@@ -16,6 +16,8 @@
 
 property layout ${agronaIT:layout("target/agrona-itest", 1024, 1024)}
 property client32 ${agronaIT:randomBytes(32)}
+property clientInt ${agronaIT:randomInt()}
+property clientLong ${agronaIT:randomLong()}
 
 connect "agrona://stream/bidirectional"
         option agrona:reader ${agrona:broadcastReceiver(layout.broadcast)}
@@ -25,10 +27,14 @@ connected
 
 write [0x00 0x00 0x00 0x01]
 write ${client32}
+write ${clientInt}
+write ${clientLong}
 write flush
 
 read [0x00 0x00 0x00 0x02]
 read ${client32}
+read ${clientInt}
+read ${clientLong}
 
 close
 closed

--- a/driver/src/test/resources/org/kaazing/k3po/driver/internal/agrona/server.rpt
+++ b/driver/src/test/resources/org/kaazing/k3po/driver/internal/agrona/server.rpt
@@ -25,9 +25,13 @@ connected
 
 read [0x00 0x00 0x00 0x01]
 read ([0..32] :server32)
+read (int :serverInt)
+read (long :serverLong)
 
 write [0x00 0x00 0x00 0x02]
 write ${server32}
+write ${serverInt}
+write ${serverLong}
 write flush
 
 close

--- a/driver/src/test/resources/org/kaazing/k3po/driver/internal/agrona/server.rpt
+++ b/driver/src/test/resources/org/kaazing/k3po/driver/internal/agrona/server.rpt
@@ -23,12 +23,12 @@ accept "agrona://stream/bidirectional"
 accepted
 connected
 
-read [0x00 0x00 0x00 0x01]
+read 0x00000001
 read ([0..32] :server32)
-read (int :serverInt)
-read (long :serverLong)
+read ([0..4] :serverInt)
+read ([0..8] :serverLong)
 
-write [0x00 0x00 0x00 0x02]
+write 0x00000002
 write ${server32}
 write ${serverInt}
 write ${serverLong}

--- a/lang/src/main/antlr4/org/kaazing/k3po/lang/parser/v2/Robot.g4
+++ b/lang/src/main/antlr4/org/kaazing/k3po/lang/parser/v2/Robot.g4
@@ -244,6 +244,7 @@ writeNotifyNode
 matcher
     : exactTextMatcher
     | exactBytesMatcher
+    | numberMatcher
     | regexMatcher
     | expressionMatcher
     | fixedLengthBytesMatcher
@@ -256,10 +257,11 @@ exactTextMatcher
 
 exactBytesMatcher
     : bytes=BytesLiteral
-    | byteLiteral=ByteLiteral
-    | shortLiteral=TwoByteLiteral
-    | intLiteral=(SignedDecimalLiteral | DecimalLiteral)
-    | longLiteral=(SignedDecimalLiteral | DecimalLiteral) 'L'
+    ;
+
+numberMatcher
+    : intLiteral=(SignedDecimalLiteral | DecimalLiteral | HexLiteral)
+    | longLiteral=(SignedDecimalLiteral | DecimalLiteral | HexLiteral) 'L'
     ;
 
 regexMatcher
@@ -288,8 +290,6 @@ variableLengthBytesMatcher
 writeValue
     : literalText
     | literalBytes
-    | literalByte
-    | literalShort
     | literalInteger
     | literalLong
     | expressionValue
@@ -303,20 +303,12 @@ literalBytes
     : literal=BytesLiteral
     ;
 
-literalByte
-    : literal=ByteLiteral
-    ;
-
-literalShort
-    : literal=TwoByteLiteral
-    ;
-
 literalInteger
-    : literal=(SignedDecimalLiteral | DecimalLiteral)
+    : literal=(SignedDecimalLiteral | DecimalLiteral | HexLiteral) 
     ;
 
 literalLong
-    : literal=(SignedDecimalLiteral | DecimalLiteral) 'L'
+    : literal=(SignedDecimalLiteral | DecimalLiteral | HexLiteral) 'L'
     ;
 
 expressionValue
@@ -487,17 +479,13 @@ BytesLiteral
     : '[' (' ')? (ByteLiteral (' ')*)+ ']'
     ;
 
-ByteLiteral
-    : HexPrefix HexDigit HexDigit
-    ;
-
-TwoByteLiteral
-    : HexPrefix HexDigit HexDigit HexDigit HexDigit
-    ;
-
 fragment
+ByteLiteral
+    :  HexPrefix HexDigit HexDigit
+    ;
+
 HexLiteral
-    : HexPrefix HexDigit+
+    : HexPrefix HexDigit ('_'? HexDigit)*
     ;
 
 fragment

--- a/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/AstWriteAbortedNode.java
+++ b/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/AstWriteAbortedNode.java
@@ -35,6 +35,6 @@ public final class AstWriteAbortedNode extends AstEventNode {
     @Override
     protected void describe(StringBuilder buf) {
         super.describe(buf);
-        buf.append("read aborted\n");
+        buf.append("write aborted\n");
     }
 }

--- a/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/builder/AstReadNodeBuilder.java
+++ b/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/builder/AstReadNodeBuilder.java
@@ -23,6 +23,7 @@ import org.kaazing.k3po.lang.internal.ast.matcher.AstExactBytesMatcher;
 import org.kaazing.k3po.lang.internal.ast.matcher.AstExactTextMatcher;
 import org.kaazing.k3po.lang.internal.ast.matcher.AstExpressionMatcher;
 import org.kaazing.k3po.lang.internal.ast.matcher.AstFixedLengthBytesMatcher;
+import org.kaazing.k3po.lang.internal.ast.matcher.AstNumberMatcher;
 import org.kaazing.k3po.lang.internal.ast.matcher.AstRegexMatcher;
 import org.kaazing.k3po.lang.internal.ast.matcher.AstVariableLengthBytesMatcher;
 import org.kaazing.k3po.lang.internal.el.ExpressionContext;
@@ -41,6 +42,11 @@ public class AstReadNodeBuilder extends AbstractAstStreamableNodeBuilder<AstRead
 
     public AstReadNodeBuilder addExactText(String exactText) {
         node.addMatcher(new AstExactTextMatcher(exactText));
+        return this;
+    }
+
+    public AstReadNodeBuilder addNumber(Number number) {
+        node.addMatcher(new AstNumberMatcher(number));
         return this;
     }
 

--- a/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/builder/AstWriteNodeBuilder.java
+++ b/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/builder/AstWriteNodeBuilder.java
@@ -21,6 +21,8 @@ import org.kaazing.k3po.lang.internal.ast.AstStreamNode;
 import org.kaazing.k3po.lang.internal.ast.AstWriteValueNode;
 import org.kaazing.k3po.lang.internal.ast.value.AstExpressionValue;
 import org.kaazing.k3po.lang.internal.ast.value.AstLiteralBytesValue;
+import org.kaazing.k3po.lang.internal.ast.value.AstLiteralIntegerValue;
+import org.kaazing.k3po.lang.internal.ast.value.AstLiteralLongValue;
 import org.kaazing.k3po.lang.internal.ast.value.AstLiteralTextValue;
 import org.kaazing.k3po.lang.internal.el.ExpressionContext;
 
@@ -37,6 +39,16 @@ public class AstWriteNodeBuilder extends AbstractAstStreamableNodeBuilder<AstWri
 
     public AstWriteNodeBuilder addExactText(String exactText) {
         node.addValue(new AstLiteralTextValue(exactText));
+        return this;
+    }
+
+    public AstWriteNodeBuilder addLong(Long value) {
+        node.addValue(new AstLiteralLongValue(value));
+        return this;
+    }
+
+    public AstWriteNodeBuilder addInteger(Integer value) {
+        node.addValue(new AstLiteralIntegerValue(value));
         return this;
     }
 

--- a/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/matcher/AstNumberMatcher.java
+++ b/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/matcher/AstNumberMatcher.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.k3po.lang.internal.ast.matcher;
+
+import static org.kaazing.k3po.lang.internal.ast.util.AstUtil.equivalent;
+
+import java.util.Objects;
+
+import org.kaazing.k3po.lang.internal.ast.AstRegion;
+
+public final class AstNumberMatcher extends AstValueMatcher {
+
+    private final Number value;
+
+    public AstNumberMatcher(Number value) {
+        if (value == null) {
+            throw new NullPointerException("value");
+        }
+        this.value = value;
+    }
+
+    public Number getValue() {
+        return value;
+    }
+
+    @Override
+    public <R, P> R accept(Visitor<R, P> visitor, P parameter) {
+
+        return visitor.visit(this, parameter);
+    }
+
+    @Override
+    protected int hashTo() {
+        return Objects.hashCode(value);
+    }
+
+    @Override
+    protected boolean equalTo(AstRegion that) {
+        return (that instanceof AstNumberMatcher) && equalTo((AstNumberMatcher) that);
+    }
+
+    protected boolean equalTo(AstNumberMatcher that) {
+        return equivalent(this.value, that.value);
+    }
+
+    @Override
+    protected void describe(StringBuilder buf) {
+        buf.append(value.toString());
+        if (value instanceof Long)
+        {
+            buf.append('L');
+        }
+    }
+}

--- a/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/matcher/AstValueMatcher.java
+++ b/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/matcher/AstValueMatcher.java
@@ -33,6 +33,8 @@ public abstract class AstValueMatcher extends AstRegion {
 
         R visit(AstExactBytesMatcher matcher, P parameter);
 
+        R visit(AstNumberMatcher matcher, P parameter);
+
         R visit(AstVariableLengthBytesMatcher matcher, P parameter);
 
         R visit(AstByteLengthBytesMatcher matcher, P parameter);

--- a/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/value/AstExpressionValue.java
+++ b/lang/src/main/java/org/kaazing/k3po/lang/internal/ast/value/AstExpressionValue.java
@@ -78,5 +78,4 @@ public final class AstExpressionValue<T> extends AstValue<T> {
     protected void describe(StringBuilder buf) {
         buf.append(format("(%s)%s", expression.getExpectedType().getSimpleName(), expression.getExpressionString()));
     }
-
 }

--- a/lang/src/test/java/org/kaazing/k3po/lang/internal/parser/ScriptParserImplTest.java
+++ b/lang/src/test/java/org/kaazing/k3po/lang/internal/parser/ScriptParserImplTest.java
@@ -20,11 +20,11 @@ import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.ACCEPT;
 import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.CLOSE;
 import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.CLOSED;
 import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.CONNECTED;
-import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.EXACT_BYTES_MATCHER;
 import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.EXPRESSION_MATCHER;
 import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.FIXED_LENGTH_BYTES_MATCHER;
 import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.LITERAL_BYTES_VALUE;
 import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.LITERAL_TEXT_VALUE;
+import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.NUMBER_MATCHER;
 import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.PROPERTY_NODE;
 import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.READ;
 import static org.kaazing.k3po.lang.internal.parser.ScriptParseStrategy.READ_ABORT;
@@ -53,7 +53,6 @@ import static org.kaazing.k3po.lang.internal.regex.NamedGroupPattern.compile;
 import static org.kaazing.k3po.lang.internal.test.junit.Assert.assertEquals;
 
 import java.net.URI;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import javax.el.ExpressionFactory;
@@ -108,6 +107,7 @@ import org.kaazing.k3po.lang.internal.ast.matcher.AstExpressionMatcher;
 import org.kaazing.k3po.lang.internal.ast.matcher.AstFixedLengthBytesMatcher;
 import org.kaazing.k3po.lang.internal.ast.matcher.AstIntLengthBytesMatcher;
 import org.kaazing.k3po.lang.internal.ast.matcher.AstLongLengthBytesMatcher;
+import org.kaazing.k3po.lang.internal.ast.matcher.AstNumberMatcher;
 import org.kaazing.k3po.lang.internal.ast.matcher.AstRegexMatcher;
 import org.kaazing.k3po.lang.internal.ast.matcher.AstShortLengthBytesMatcher;
 import org.kaazing.k3po.lang.internal.ast.matcher.AstValueMatcher;
@@ -203,77 +203,14 @@ public class ScriptParserImplTest {
     }
 
     @Test
-    public void shouldParseShortLiteral() throws Exception {
-
-        String scriptFragment = "0x0005";
-
-        ScriptParserImpl parser = new ScriptParserImpl();
-        AstExactBytesMatcher actual = parser.parseWithStrategy(scriptFragment, EXACT_BYTES_MATCHER);
-
-        byte[] arr = {0x00, 0x05};
-
-        AstExactBytesMatcher expected = new AstExactBytesMatcher(arr);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void shouldParseShortNegativeLiteral() throws Exception {
-
-        String scriptFragment = "0xFFFB";
-
-        ScriptParserImpl parser = new ScriptParserImpl();
-        AstExactBytesMatcher actual = parser.parseWithStrategy(scriptFragment, EXACT_BYTES_MATCHER);
-
-        byte[] arr = ByteBuffer.allocate(2).putShort((short) -5).array();
-
-        AstExactBytesMatcher expected = new AstExactBytesMatcher(arr);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void shouldParseNegativeByteLiteral() throws Exception {
-
-        String scriptFragment = "0xFB";
-
-        ScriptParserImpl parser = new ScriptParserImpl();
-        AstExactBytesMatcher actual = parser.parseWithStrategy(scriptFragment, EXACT_BYTES_MATCHER);
-
-        byte[] arr = {(byte) -5};
-
-        AstExactBytesMatcher expected = new AstExactBytesMatcher(arr);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void shouldParseByteLiteral() throws Exception {
-
-        String scriptFragment = "0x05";
-
-        ScriptParserImpl parser = new ScriptParserImpl();
-        AstExactBytesMatcher actual = parser.parseWithStrategy(scriptFragment, EXACT_BYTES_MATCHER);
-
-        byte[] arr = {0x05};
-
-        AstExactBytesMatcher expected = new AstExactBytesMatcher(arr);
-
-        assertEquals(expected, actual);
-    }
-
-    @Test
     public void shouldParseIntLiteral() throws Exception {
 
         String scriptFragment = "5";
 
         ScriptParserImpl parser = new ScriptParserImpl();
-        AstExactBytesMatcher actual = parser.parseWithStrategy(scriptFragment, EXACT_BYTES_MATCHER);
+        AstNumberMatcher actual = parser.parseWithStrategy(scriptFragment, NUMBER_MATCHER);
 
-        byte[] arr = {0x00, 0x00, 0x00, 0x05};
-
-        AstExactBytesMatcher expected = new AstExactBytesMatcher(arr);
-
+        AstNumberMatcher expected = new AstNumberMatcher(5);
         assertEquals(expected, actual);
     }
 
@@ -283,12 +220,45 @@ public class ScriptParserImplTest {
         String scriptFragment = "-5";
 
         ScriptParserImpl parser = new ScriptParserImpl();
-        AstExactBytesMatcher actual = parser.parseWithStrategy(scriptFragment, EXACT_BYTES_MATCHER);
+        AstNumberMatcher actual = parser.parseWithStrategy(scriptFragment, NUMBER_MATCHER);
 
-        byte[] arr = ByteBuffer.allocate(4).putInt(-5).array();
+        AstNumberMatcher expected = new AstNumberMatcher(-5);
+        assertEquals(expected, actual);
+    }
 
-        AstExactBytesMatcher expected = new AstExactBytesMatcher(arr);
+    @Test
+    public void shouldParseHexIntLiteral() throws Exception {
 
+        String scriptFragment = "0x00000005";
+
+        ScriptParserImpl parser = new ScriptParserImpl();
+        AstNumberMatcher actual = parser.parseWithStrategy(scriptFragment, NUMBER_MATCHER);
+
+        AstNumberMatcher expected = new AstNumberMatcher(5);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldParseHexIntLiteralWithUnderscores() throws Exception {
+
+        String scriptFragment = "0x0000_0005";
+
+        ScriptParserImpl parser = new ScriptParserImpl();
+        AstNumberMatcher actual = parser.parseWithStrategy(scriptFragment, NUMBER_MATCHER);
+
+        AstNumberMatcher expected = new AstNumberMatcher(5);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldParseHexBriefIntLiteral() throws Exception {
+
+        String scriptFragment = "0x5";
+
+        ScriptParserImpl parser = new ScriptParserImpl();
+        AstNumberMatcher actual = parser.parseWithStrategy(scriptFragment, NUMBER_MATCHER);
+
+        AstNumberMatcher expected = new AstNumberMatcher(5);
         assertEquals(expected, actual);
     }
 
@@ -298,11 +268,9 @@ public class ScriptParserImplTest {
         String scriptFragment = "5L";
 
         ScriptParserImpl parser = new ScriptParserImpl();
-        AstExactBytesMatcher actual = parser.parseWithStrategy(scriptFragment, EXACT_BYTES_MATCHER);
+        AstNumberMatcher actual = parser.parseWithStrategy(scriptFragment, NUMBER_MATCHER);
 
-        byte[] arr = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05};
-
-        AstExactBytesMatcher expected = new AstExactBytesMatcher(arr);
+        AstNumberMatcher expected = new AstNumberMatcher(5L);
 
         assertEquals(expected, actual);
     }
@@ -313,11 +281,45 @@ public class ScriptParserImplTest {
         String scriptFragment = "-5L";
 
         ScriptParserImpl parser = new ScriptParserImpl();
-        AstExactBytesMatcher actual = parser.parseWithStrategy(scriptFragment, EXACT_BYTES_MATCHER);
+        AstNumberMatcher actual = parser.parseWithStrategy(scriptFragment, NUMBER_MATCHER);
 
-        byte[] arr = ByteBuffer.allocate(8).putLong(-5).array();
+        AstNumberMatcher expected = new AstNumberMatcher(-5L);
+        assertEquals(expected, actual);
+    }
 
-        AstExactBytesMatcher expected = new AstExactBytesMatcher(arr);
+    @Test
+    public void shouldParseHexLongLiteral() throws Exception {
+
+        String scriptFragment = "0x0000000000000005L";
+
+        ScriptParserImpl parser = new ScriptParserImpl();
+        AstNumberMatcher actual = parser.parseWithStrategy(scriptFragment, NUMBER_MATCHER);
+
+        AstNumberMatcher expected = new AstNumberMatcher(5L);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldParseHexLongLiteralWithUnderscores() throws Exception {
+
+        String scriptFragment = "0x0000_0000_0000_0005L";
+
+        ScriptParserImpl parser = new ScriptParserImpl();
+        AstNumberMatcher actual = parser.parseWithStrategy(scriptFragment, NUMBER_MATCHER);
+
+        AstNumberMatcher expected = new AstNumberMatcher(5L);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldParseHexBriefLongLiteral() throws Exception {
+
+        String scriptFragment = "0x5L";
+
+        ScriptParserImpl parser = new ScriptParserImpl();
+        AstNumberMatcher actual = parser.parseWithStrategy(scriptFragment, NUMBER_MATCHER);
+
+        AstNumberMatcher expected = new AstNumberMatcher(5L);
         assertEquals(expected, actual);
     }
 
@@ -792,7 +794,7 @@ public class ScriptParserImplTest {
 
     @Test
     public void shouldParseWriteMultAllValue() throws Exception {
-        String scriptFragment = "write \"Hello\" [0x01 0x02] ${var1}";
+        String scriptFragment = "write \"Hello\" [0x01 0x02] ${var1} 5 5L 0x5 0x5L 0x0000_0005 0x0000_0000_0000_0005L";
 
         ScriptParserImpl parser = new ScriptParserImpl();
         AstWriteValueNode actual = parser.parseWithStrategy(scriptFragment, WRITE);
@@ -805,10 +807,17 @@ public class ScriptParserImplTest {
                         .addExactText("Hello")
                         .addExactBytes(new byte[]{0x01, (byte) 0x02})
                         .addExpression(factory.createValueExpression(context, "${var1}", byte[].class),
-                                parser.getExpressionContext()).done();
+                                parser.getExpressionContext())
+                        .addInteger(5)
+                        .addLong(5L)
+                        .addInteger(5)
+                        .addLong(5L)
+                        .addInteger(5)
+                        .addLong(5L)
+                        .done();
 
         assertEquals(expected, actual);
-        assertEquals(3, actual.getRegionInfo().children.size());
+        assertEquals(9, actual.getRegionInfo().children.size());
     }
 
     @Test
@@ -969,37 +978,7 @@ public class ScriptParserImplTest {
     }
 
     @Test
-    public void shouldParseReadExactByte() throws Exception {
-
-        String scriptFragment = "read 0x05";
-
-        ScriptParserImpl parser = new ScriptParserImpl();
-        AstReadValueNode actual = parser.parseWithStrategy(scriptFragment, READ);
-
-        AstReadValueNode expected =
-                new AstReadNodeBuilder().addExactBytes(new byte[]{0x05}, parser.getExpressionContext()).done();
-
-        assertEquals(expected, actual);
-        assertEquals(1, actual.getRegionInfo().children.size());
-    }
-
-    @Test
-    public void shouldParseReadExactShort() throws Exception {
-
-        String scriptFragment = "read 0x0005";
-
-        ScriptParserImpl parser = new ScriptParserImpl();
-        AstReadValueNode actual = parser.parseWithStrategy(scriptFragment, READ);
-
-        AstReadValueNode expected =
-                new AstReadNodeBuilder().addExactBytes(new byte[]{0x00, 0x05}, parser.getExpressionContext()).done();
-
-        assertEquals(expected, actual);
-        assertEquals(1, actual.getRegionInfo().children.size());
-    }
-
-    @Test
-    public void shouldParseReadExactInt() throws Exception {
+    public void shouldParseReadLiteralInt() throws Exception {
 
         String scriptFragment = "read 5";
 
@@ -1007,15 +986,44 @@ public class ScriptParserImplTest {
         AstReadValueNode actual = parser.parseWithStrategy(scriptFragment, READ);
 
         AstReadValueNode expected = new AstReadNodeBuilder()
-
-        .addExactBytes(new byte[]{0x00, 0x00, 0x00, 0x05}, parser.getExpressionContext()).done();
+                .addNumber(5).done();
 
         assertEquals(expected, actual);
         assertEquals(1, actual.getRegionInfo().children.size());
     }
 
     @Test
-    public void shouldParseReadExactLong() throws Exception {
+    public void shouldParseReadLiteralHexInt() throws Exception {
+
+        String scriptFragment = "read 0x00000005";
+
+        ScriptParserImpl parser = new ScriptParserImpl();
+        AstReadValueNode actual = parser.parseWithStrategy(scriptFragment, READ);
+
+        AstReadValueNode expected = new AstReadNodeBuilder()
+                .addNumber(5).done();
+
+        assertEquals(expected, actual);
+        assertEquals(1, actual.getRegionInfo().children.size());
+    }
+
+    @Test
+    public void shouldParseReadLiteralHexIntWithUnderscores() throws Exception {
+
+        String scriptFragment = "read 0x0000_0005";
+
+        ScriptParserImpl parser = new ScriptParserImpl();
+        AstReadValueNode actual = parser.parseWithStrategy(scriptFragment, READ);
+
+        AstReadValueNode expected = new AstReadNodeBuilder()
+                .addNumber(5).done();
+
+        assertEquals(expected, actual);
+        assertEquals(1, actual.getRegionInfo().children.size());
+    }
+
+    @Test
+    public void shouldParseReadLiteralLong() throws Exception {
 
         String scriptFragment = "read 5L";
 
@@ -1023,8 +1031,52 @@ public class ScriptParserImplTest {
         AstReadValueNode actual = parser.parseWithStrategy(scriptFragment, READ);
 
         AstReadValueNode expected = new AstReadNodeBuilder()
+                .addNumber(5L).done();
 
-        .addExactBytes(new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05}, parser.getExpressionContext()).done();
+        assertEquals(expected, actual);
+        assertEquals(1, actual.getRegionInfo().children.size());
+    }
+
+    @Test
+    public void shouldParseReadLiteralHexBriefLong() throws Exception {
+
+        String scriptFragment = "read 0x5L";
+
+        ScriptParserImpl parser = new ScriptParserImpl();
+        AstReadValueNode actual = parser.parseWithStrategy(scriptFragment, READ);
+
+        AstReadValueNode expected = new AstReadNodeBuilder()
+                .addNumber(5L).done();
+
+        assertEquals(expected, actual);
+        assertEquals(1, actual.getRegionInfo().children.size());
+    }
+
+    @Test
+    public void shouldParseReadLiteralHexLong() throws Exception {
+
+        String scriptFragment = "read 0x0000000000000005L";
+
+        ScriptParserImpl parser = new ScriptParserImpl();
+        AstReadValueNode actual = parser.parseWithStrategy(scriptFragment, READ);
+
+        AstReadValueNode expected = new AstReadNodeBuilder()
+                .addNumber(5L).done();
+
+        assertEquals(expected, actual);
+        assertEquals(1, actual.getRegionInfo().children.size());
+    }
+
+    @Test
+    public void shouldParseReadLiteralHexLongWithUnderscores() throws Exception {
+
+        String scriptFragment = "read 0x0000_0000_0000_0005L";
+
+        ScriptParserImpl parser = new ScriptParserImpl();
+        AstReadValueNode actual = parser.parseWithStrategy(scriptFragment, READ);
+
+        AstReadValueNode expected = new AstReadNodeBuilder()
+                .addNumber(5L).done();
 
         assertEquals(expected, actual);
         assertEquals(1, actual.getRegionInfo().children.size());


### PR DESCRIPTION
Implicitly use native byte order for `agrona` transport.