### PR TITLE
TLS ALPN negotiation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: Java
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 install: mvn -e -DskipTests -DskipITs verify
 script: mvn verify
 sudo: false

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/TlsTypeSystem.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/TlsTypeSystem.java
@@ -33,6 +33,7 @@ public final class TlsTypeSystem implements TypeSystemSpi
     public static final TypeInfo<String> OPTION_KEY_STORE_PASSWORD = new TypeInfo<>("keyStorePassword", String.class);
     public static final TypeInfo<String> OPTION_TRUST_STORE_FILE = new TypeInfo<>("trustStoreFile", String.class);
     public static final TypeInfo<String> OPTION_TRUST_STORE_PASSWORD = new TypeInfo<>("trustStorePassword", String.class);
+    public static final TypeInfo<String> OPTION_APPLICATION_PROTOCOLS = new TypeInfo<>("applicationProtocols", String.class);
 
     private final Set<TypeInfo<?>> acceptOptions;
     private final Set<TypeInfo<?>> connectOptions;
@@ -49,6 +50,7 @@ public final class TlsTypeSystem implements TypeSystemSpi
         acceptOptions.add(OPTION_KEY_STORE_PASSWORD);
         acceptOptions.add(OPTION_TRUST_STORE_FILE);
         acceptOptions.add(OPTION_TRUST_STORE_PASSWORD);
+        acceptOptions.add(OPTION_APPLICATION_PROTOCOLS);
         this.acceptOptions = unmodifiableSet(acceptOptions);
 
         Set<TypeInfo<?>> connectOptions = new LinkedHashSet<>();
@@ -57,6 +59,7 @@ public final class TlsTypeSystem implements TypeSystemSpi
         connectOptions.add(OPTION_KEY_STORE_PASSWORD);
         connectOptions.add(OPTION_TRUST_STORE_FILE);
         connectOptions.add(OPTION_TRUST_STORE_PASSWORD);
+        connectOptions.add(OPTION_APPLICATION_PROTOCOLS);
         this.connectOptions = unmodifiableSet(connectOptions);
 
         this.readOptions = emptySet();

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/DefaultTlsChannelConfig.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/DefaultTlsChannelConfig.java
@@ -28,6 +28,7 @@ public class DefaultTlsChannelConfig extends DefaultChannelConfig implements Tls
     private char[] keyStorePassword;
     private File trustStoreFile;
     private char[] trustStorePassword;
+    private String[] applicationProtocols;
 
     @Override
     public void setParameters(SSLParameters parameters) {
@@ -92,6 +93,19 @@ public class DefaultTlsChannelConfig extends DefaultChannelConfig implements Tls
     }
 
     @Override
+    public String[] getApplicationProtocols()
+    {
+        return applicationProtocols;
+    }
+
+    @Override
+    public void setApplicationProtocols(
+        String[] applicationProtocol)
+    {
+        this.applicationProtocols = applicationProtocol;
+    }
+
+    @Override
     protected boolean setOption0(
         String key,
         Object value)
@@ -111,6 +125,10 @@ public class DefaultTlsChannelConfig extends DefaultChannelConfig implements Tls
         else if ("trustStorePassword".equals(key))
         {
             trustStorePassword = ((String) value).toCharArray();
+        }
+        else if ("applicationProtocols".equals(key))
+        {
+            applicationProtocols = ((String) value).split(",");
         }
         else
         {

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/DefaultTlsServerChannelConfig.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/DefaultTlsServerChannelConfig.java
@@ -28,6 +28,7 @@ public class DefaultTlsServerChannelConfig extends DefaultServerChannelConfig im
     private char[] keyStorePassword;
     private File trustStoreFile;
     private char[] trustStorePassword;
+    private String[] applicationProtocols;
 
     @Override
     public void setParameters(SSLParameters parameters) {
@@ -92,6 +93,19 @@ public class DefaultTlsServerChannelConfig extends DefaultServerChannelConfig im
     }
 
     @Override
+    public String[] getApplicationProtocols()
+    {
+        return applicationProtocols;
+    }
+
+    @Override
+    public void setApplicationProtocols(
+            String[] applicationProtocol)
+    {
+        this.applicationProtocols = applicationProtocol;
+    }
+
+    @Override
     protected boolean setOption0(
         String key,
         Object value)
@@ -111,6 +125,10 @@ public class DefaultTlsServerChannelConfig extends DefaultServerChannelConfig im
         else if ("trustStorePassword".equals(key))
         {
             trustStorePassword = ((String) value).toCharArray();
+        }
+        else if ("applicationProtocols".equals(key))
+        {
+            applicationProtocols = ((String) value).split(",");
         }
         else
         {

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsChannelConfig.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsChannelConfig.java
@@ -42,4 +42,8 @@ public interface TlsChannelConfig extends ChannelConfig {
     void setTrustStorePassword(char[] trustStorePassword);
 
     char[] getTrustStorePassword();
+
+    void setApplicationProtocols(String[] applicationProtocol);
+
+    String[] getApplicationProtocols();
 }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsClientChannelSink.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsClientChannelSink.java
@@ -32,6 +32,8 @@ import static org.kaazing.k3po.driver.internal.netty.channel.Channels.fireInputS
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.security.KeyStore;
 import java.security.SecureRandom;
@@ -166,6 +168,7 @@ public class TlsClientChannelSink extends AbstractChannelSink {
                 SSLParameters tlsParameters = tlsEngine.getSSLParameters();
                 tlsParameters.setEndpointIdentificationAlgorithm("HTTPS");
                 tlsParameters.setServerNames(asList(new SNIHostName(tlsHostname)));
+setApplicationProtocols(tlsParameters, new String[] { "protocol" });        // TODO config
                 tlsEngine.setSSLParameters(tlsParameters);
 
                 SslHandler sslHandler = new SslHandler(tlsEngine);
@@ -350,5 +353,15 @@ public class TlsClientChannelSink extends AbstractChannelSink {
                 transport.getCloseFuture().removeListener(closeListener);
             }
         });
+    }
+
+    static void setApplicationProtocols(SSLParameters parameters, String[] protocols) {
+        try {
+            Method setApplicationProtocolsMethod = SSLParameters.class.getMethod("setApplicationProtocols", String[].class);
+            setApplicationProtocolsMethod.invoke(parameters, new Object[] { protocols } );
+        } catch (Throwable t) {
+            t.printStackTrace();
+            System.out.println("********** Cannot call SSLParameters#setApplicationProtocols(). Use JDK 9 to run k3po");
+        }
     }
 }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsClientChannelSink.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsClientChannelSink.java
@@ -128,7 +128,7 @@ public class TlsClientChannelSink extends AbstractChannelSink {
         File trustStoreFile = tlsConnectConfig.getTrustStoreFile();
         char[] keyStorePassword = tlsConnectConfig.getKeyStorePassword();
         char[] trustStorePassword = tlsConnectConfig.getTrustStorePassword();
-        String[] applicationProtocol = tlsConnectConfig.getApplicationProtocols();
+        String[] applicationProtocols = tlsConnectConfig.getApplicationProtocols();
 
         ChannelPipelineFactory pipelineFactory = new ChannelPipelineFactory() {
             @Override
@@ -168,8 +168,8 @@ public class TlsClientChannelSink extends AbstractChannelSink {
                 SSLParameters tlsParameters = tlsEngine.getSSLParameters();
                 tlsParameters.setEndpointIdentificationAlgorithm("HTTPS");
                 tlsParameters.setServerNames(asList(new SNIHostName(tlsHostname)));
-                if (applicationProtocol != null && applicationProtocol.length > 0) {
-                    setApplicationProtocols(tlsParameters, applicationProtocol);
+                if (applicationProtocols != null && applicationProtocols.length > 0) {
+                    setApplicationProtocols(tlsParameters, applicationProtocols);
                 }
                 tlsEngine.setSSLParameters(tlsParameters);
 

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsServerChannelSink.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsServerChannelSink.java
@@ -97,7 +97,7 @@ public class TlsServerChannelSink extends AbstractServerChannelSink<TlsServerCha
             File trustStoreFile = tlsConnectConfig.getTrustStoreFile();
             char[] keyStorePassword = tlsConnectConfig.getKeyStorePassword();
             char[] trustStorePassword = tlsConnectConfig.getTrustStorePassword();
-            String[] applicationProtocol = tlsConnectConfig.getApplicationProtocols();
+            String[] applicationProtocols = tlsConnectConfig.getApplicationProtocols();
 
             ChannelPipelineFactory pipelineFactory = new ChannelPipelineFactory() {
                 @Override
@@ -136,8 +136,8 @@ public class TlsServerChannelSink extends AbstractServerChannelSink<TlsServerCha
 
                     SSLParameters tlsParameters = new SSLParameters();
                     tlsParameters.setSNIMatchers(singleton(createSNIMatcher(tlsHostname)));
-                    if (applicationProtocol != null && applicationProtocol.length > 0) {
-                        setApplicationProtocols(tlsParameters, applicationProtocol);
+                    if (applicationProtocols != null && applicationProtocols.length > 0) {
+                        setApplicationProtocols(tlsParameters, applicationProtocols);
                     }
                     tlsEngine.setSSLParameters(tlsParameters);
 

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsServerChannelSink.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsServerChannelSink.java
@@ -25,6 +25,8 @@ import static org.jboss.netty.channel.Channels.pipeline;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.security.KeyStore;
 import java.security.SecureRandom;
@@ -133,6 +135,7 @@ public class TlsServerChannelSink extends AbstractServerChannelSink<TlsServerCha
 
                     SSLParameters tlsParameters = new SSLParameters();
                     tlsParameters.setSNIMatchers(singleton(createSNIMatcher(tlsHostname)));
+setApplicationProtocols(tlsParameters, new String[] { "protocol" });        // TODO config
                     tlsEngine.setSSLParameters(tlsParameters);
 
                     SslHandler sslHandler = new SslHandler(tlsEngine);
@@ -332,4 +335,14 @@ public class TlsServerChannelSink extends AbstractServerChannelSink<TlsServerCha
             return format("[future=@%d, count=%d]", Objects.hashCode(future), count.get());
         }
     }
+
+    static void setApplicationProtocols(SSLParameters parameters, String[] protocols) {
+        try {
+            Method setApplicationProtocolsMethod = SSLParameters.class.getMethod("setApplicationProtocols", String[].class);
+            setApplicationProtocolsMethod.invoke(parameters, new Object[] { protocols });
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            System.out.println("Cannot call SSLParameters#setApplicationProtocols(). Use JDK 9 to run k3po");
+        }
+    }
+
 }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsServerChannelSink.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsServerChannelSink.java
@@ -97,6 +97,7 @@ public class TlsServerChannelSink extends AbstractServerChannelSink<TlsServerCha
             File trustStoreFile = tlsConnectConfig.getTrustStoreFile();
             char[] keyStorePassword = tlsConnectConfig.getKeyStorePassword();
             char[] trustStorePassword = tlsConnectConfig.getTrustStorePassword();
+            String[] applicationProtocol = tlsConnectConfig.getApplicationProtocols();
 
             ChannelPipelineFactory pipelineFactory = new ChannelPipelineFactory() {
                 @Override
@@ -135,7 +136,9 @@ public class TlsServerChannelSink extends AbstractServerChannelSink<TlsServerCha
 
                     SSLParameters tlsParameters = new SSLParameters();
                     tlsParameters.setSNIMatchers(singleton(createSNIMatcher(tlsHostname)));
-setApplicationProtocols(tlsParameters, new String[] { "protocol" });        // TODO config
+                    if (applicationProtocol != null && applicationProtocol.length > 0) {
+                        setApplicationProtocols(tlsParameters, applicationProtocol);
+                    }
                     tlsEngine.setSSLParameters(tlsParameters);
 
                     SslHandler sslHandler = new SslHandler(tlsEngine);
@@ -341,7 +344,7 @@ setApplicationProtocols(tlsParameters, new String[] { "protocol" });        // T
             Method setApplicationProtocolsMethod = SSLParameters.class.getMethod("setApplicationProtocols", String[].class);
             setApplicationProtocolsMethod.invoke(parameters, new Object[] { protocols });
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            System.out.println("Cannot call SSLParameters#setApplicationProtocols(). Use JDK 9 to run k3po");
+            throw new RuntimeException("Cannot call SSLParameters#setApplicationProtocols(). Use JDK 9 to run k3po", e);
         }
     }
 

--- a/driver/src/test/java/org/kaazing/k3po/driver/internal/tls/TlsIT.java
+++ b/driver/src/test/java/org/kaazing/k3po/driver/internal/tls/TlsIT.java
@@ -18,7 +18,6 @@ package org.kaazing.k3po.driver.internal.tls;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -45,7 +44,6 @@ public class TlsIT {
         k3po.finish();
     }
 
-    @Ignore("Needs JDK 9 to run as it uses SSLParameters#setApplicationProtocols()")
     @Test
     @TestSpecification({
         "connection.established.with.alpn/server",

--- a/driver/src/test/java/org/kaazing/k3po/driver/internal/tls/TlsIT.java
+++ b/driver/src/test/java/org/kaazing/k3po/driver/internal/tls/TlsIT.java
@@ -18,6 +18,7 @@ package org.kaazing.k3po.driver.internal.tls;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -41,6 +42,16 @@ public class TlsIT {
         "connection.established/client"
     })
     public void shouldEstablishConnection() throws Exception {
+        k3po.finish();
+    }
+
+    @Ignore("Needs JDK 9 to run as it uses SSLParameters#setApplicationProtocols()")
+    @Test
+    @TestSpecification({
+        "connection.established.with.alpn/server",
+        "connection.established.with.alpn/client"
+    })
+    public void shouldEstablishConnectionWithAlpn() throws Exception {
         k3po.finish();
     }
 

--- a/driver/src/test/resources/org/kaazing/k3po/driver/internal/tls/connection.established.with.alpn/client.rpt
+++ b/driver/src/test/resources/org/kaazing/k3po/driver/internal/tls/connection.established.with.alpn/client.rpt
@@ -1,0 +1,22 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect "tls://localhost:8001"
+        option tls:trustStoreFile "src/test/democa/cacerts"
+        option tls:trustStorePassword "generated"
+        option tls:applicationProtocols "h2, http/1.1"
+
+connected

--- a/driver/src/test/resources/org/kaazing/k3po/driver/internal/tls/connection.established.with.alpn/client.rpt
+++ b/driver/src/test/resources/org/kaazing/k3po/driver/internal/tls/connection.established.with.alpn/client.rpt
@@ -17,6 +17,6 @@
 connect "tls://localhost:8001"
         option tls:trustStoreFile "src/test/democa/cacerts"
         option tls:trustStorePassword "generated"
-        option tls:applicationProtocols "h2, http/1.1"
+        option tls:applicationProtocols "http/1.1,h2"
 
 connected

--- a/driver/src/test/resources/org/kaazing/k3po/driver/internal/tls/connection.established.with.alpn/server.rpt
+++ b/driver/src/test/resources/org/kaazing/k3po/driver/internal/tls/connection.established.with.alpn/server.rpt
@@ -1,0 +1,23 @@
+#
+# Copyright 2007-2015, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+accept "tls://localhost:8001"
+       option tls:keyStoreFile "src/test/democa/localhost"
+       option tls:keyStorePassword "generated"
+       option tls:applicationProtocols "h2"
+
+accepted
+connected


### PR DESCRIPTION
Setting SSLParameters#setApplicationProtocols() to start ALPN negotiation.
Since the call is only available in Java 9, it is being invoked using reflection.