### PR TITLE
Moving to PKIX KeyManagerFactory

### DIFF
--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsClientChannelSink.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsClientChannelSink.java
@@ -141,7 +141,7 @@ public class TlsClientChannelSink extends AbstractChannelSink {
                     KeyStore keys = KeyStore.getInstance("JKS");
                     keys.load(new FileInputStream(keyStoreFile), keyStorePassword);
 
-                    KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+                    KeyManagerFactory kmf = KeyManagerFactory.getInstance("PKIX");
                     kmf.init(keys, keyStorePassword);
                     keyManagers = kmf.getKeyManagers();
                 }
@@ -152,7 +152,7 @@ public class TlsClientChannelSink extends AbstractChannelSink {
                     KeyStore trusts = KeyStore.getInstance("JKS");
                     trusts.load(new FileInputStream(trustStoreFile), trustStorePassword);
 
-                    TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+                    TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
                     tmf.init(trusts);
                     trustManagers = tmf.getTrustManagers();
                 }

--- a/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsServerChannelSink.java
+++ b/driver/src/main/java/org/kaazing/k3po/driver/internal/ext/tls/bootstrap/TlsServerChannelSink.java
@@ -111,7 +111,7 @@ public class TlsServerChannelSink extends AbstractServerChannelSink<TlsServerCha
                         KeyStore keys = KeyStore.getInstance("JKS");
                         keys.load(new FileInputStream(keyStoreFile), keyStorePassword);
 
-                        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+                        KeyManagerFactory kmf = KeyManagerFactory.getInstance("PKIX");
                         kmf.init(keys, keyStorePassword);
                         keyManagers = kmf.getKeyManagers();
                     }
@@ -122,7 +122,7 @@ public class TlsServerChannelSink extends AbstractServerChannelSink<TlsServerCha
                         KeyStore trusts = KeyStore.getInstance("JKS");
                         trusts.load(new FileInputStream(trustStoreFile), trustStorePassword);
 
-                        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+                        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
                         tmf.init(trusts);
                         trustManagers = tmf.getTrustManagers();
                     }


### PR DESCRIPTION
Moving to PKIX KeyManagerFactory (which uses SNI while choosing a key
from multiple keys in a keystore)